### PR TITLE
Optimize compile-time performance with loop constant hoisting and improved memory access patterns

### DIFF
--- a/enchantum/include/enchantum/details/enchantum_clang.hpp
+++ b/enchantum/include/enchantum/details/enchantum_clang.hpp
@@ -59,6 +59,7 @@ namespace details {
     std::size_t&        valid_count)
   {
     (void)index_check;
+    constexpr std::size_t skip_after_comma = SZC(", ");
     for (std::size_t index = 0; index < array_size; ++index) {
 #if __clang_major__ > 12
       // check if cast (starts with '(')
@@ -68,7 +69,7 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + skip_after_comma;
       }
       else {
         str += least_length_when_value;
@@ -80,7 +81,7 @@ namespace details {
         string_lengths[valid_count++] = static_cast<std::uint8_t>(commapos);
         __builtin_memcpy(strings + total_string_length, str, commapos);
         total_string_length += commapos + null_terminated;
-        str += commapos + SZC(", ");
+        str += commapos + skip_after_comma;
       }
     }
   }

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -129,9 +129,10 @@ namespace details {
     std::size_t&        valid_count)
   {
     (void)min; // not always used
+    constexpr std::size_t skip_after_comma = SZC(", ");
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + skip_after_comma;
       }
       else {
         str += least_length_when_value;
@@ -146,7 +147,7 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
-        str += commapos + SZC(", ");
+        str += commapos + skip_after_comma;
       }
     }
   }
@@ -203,10 +204,10 @@ namespace details {
       decltype(elements_local) elements;
       Strings                  strings{};
     } data = {elements_local};
-    const auto  size        = data.strings.size();
     auto* const data_string = data.strings.data();
-    for (std::size_t i = 0; i < size; ++i)
-      data_string[i] = elements_local.strings[i];
+    const auto* const src_string = elements_local.strings;
+    for (std::size_t i = 0, size = data.strings.size(); i < size; ++i)
+      data_string[i] = src_string[i];
     return data;
   }
 

--- a/enchantum/include/enchantum/details/enchantum_msvc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_msvc.hpp
@@ -84,6 +84,7 @@ namespace details {
         ? sizeof(char32_t)*2-1 : sizeof(std::uint64_t)*2-1 - (sizeof(IntType)==8); // subtract 1 more from uint64_t since I am adding it in skip_if_cast_count
 #endif
     // clang-format on
+    constexpr std::size_t skip_comma = SZC(",");
     for (std::size_t index = 0; index < array_size; ++index) {
 #if _MSC_VER <= 1924
       // if it starts with the number 0 (because of 0x0) then it is a value
@@ -125,7 +126,7 @@ namespace details {
         string_lengths[valid_count++] = static_cast<std::uint8_t>(i);
 
         total_string_length += null_terminated;
-        str += i + SZC(",");
+        str += i + skip_comma;
       }
     }
   }
@@ -179,10 +180,10 @@ namespace details {
       Strings                  strings{};
     } data = {elements_local};
 
-    const auto  size     = data.strings.size();
     auto* const data_string = data.strings.data();
-    for (std::size_t i = 0; i < size; ++i)
-      data_string[i] = elements_local.strings[i];
+    const auto* const src_string = elements_local.strings;
+    for (std::size_t i = 0, size = data.strings.size(); i < size; ++i)
+      data_string[i] = src_string[i];
     return data;
   }
 } // namespace details

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -572,6 +572,7 @@ namespace details {
     std::size_t&        valid_count)
   {
     (void)index_check;
+    constexpr std::size_t skip_after_comma = SZC(", ");
     for (std::size_t index = 0; index < array_size; ++index) {
 #if __clang_major__ > 12
       // check if cast (starts with '(')
@@ -581,7 +582,7 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + skip_after_comma;
       }
       else {
         str += least_length_when_value;
@@ -593,7 +594,7 @@ namespace details {
         string_lengths[valid_count++] = static_cast<std::uint8_t>(commapos);
         __builtin_memcpy(strings + total_string_length, str, commapos);
         total_string_length += commapos + null_terminated;
-        str += commapos + SZC(", ");
+        str += commapos + skip_after_comma;
       }
     }
   }
@@ -799,9 +800,10 @@ namespace details {
     std::size_t&        valid_count)
   {
     (void)min; // not always used
+    constexpr std::size_t skip_after_comma = SZC(", ");
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + skip_after_comma;
       }
       else {
         str += least_length_when_value;
@@ -816,7 +818,7 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
-        str += commapos + SZC(", ");
+        str += commapos + skip_after_comma;
       }
     }
   }
@@ -871,10 +873,10 @@ namespace details {
       decltype(elements_local) elements;
       Strings                  strings{};
     } data = {elements_local};
-    const auto  size        = data.strings.size();
     auto* const data_string = data.strings.data();
-    for (std::size_t i = 0; i < size; ++i)
-      data_string[i] = elements_local.strings[i];
+    const auto* const src_string = elements_local.strings;
+    for (std::size_t i = 0, size = data.strings.size(); i < size; ++i)
+      data_string[i] = src_string[i];
     return data;
   }
 
@@ -971,6 +973,7 @@ namespace details {
         ? sizeof(char32_t)*2-1 : sizeof(std::uint64_t)*2-1 - (sizeof(IntType)==8); // subtract 1 more from uint64_t since I am adding it in skip_if_cast_count
 #endif
     // clang-format on
+    constexpr std::size_t skip_comma = SZC(",");
     for (std::size_t index = 0; index < array_size; ++index) {
 #if _MSC_VER <= 1924
       // if it starts with the number 0 (because of 0x0) then it is a value
@@ -1011,7 +1014,7 @@ namespace details {
         string_lengths[valid_count++] = static_cast<std::uint8_t>(i);
 
         total_string_length += null_terminated;
-        str += i + SZC(",");
+        str += i + skip_comma;
       }
     }
   }
@@ -1064,10 +1067,10 @@ namespace details {
       Strings                  strings{};
     } data = {elements_local};
 
-    const auto  size     = data.strings.size();
     auto* const data_string = data.strings.data();
-    for (std::size_t i = 0; i < size; ++i)
-      data_string[i] = elements_local.strings[i];
+    const auto* const src_string = elements_local.strings;
+    for (std::size_t i = 0, size = data.strings.size(); i < size; ++i)
+      data_string[i] = src_string[i];
     return data;
   }
 } // namespace details


### PR DESCRIPTION
This pull request refactors internal string parsing logic in the Enchantum library to improve code clarity and maintainability across all supported compilers (Clang, GCC, and MSVC). The main changes involve introducing named constants for skip lengths after commas, and simplifying string copying logic in data structures. These changes are applied consistently in both the main library and the single-header distribution.

**String parsing and copying improvements:**

* Introduced named constants (`skip_after_comma`, `skip_comma`) to replace repeated inline expressions for skipping over commas in string parsing logic, making the code clearer and reducing the risk of mistakes. [[1]](diffhunk://#diff-f236b842ad08cf09c8a84491e7e24b3ba7b4b39fb4be425fb0752e3bdc462eebR62) [[2]](diffhunk://#diff-f236b842ad08cf09c8a84491e7e24b3ba7b4b39fb4be425fb0752e3bdc462eebL71-R72) [[3]](diffhunk://#diff-f236b842ad08cf09c8a84491e7e24b3ba7b4b39fb4be425fb0752e3bdc462eebL83-R84) [[4]](diffhunk://#diff-27c6488a232eee927f03ca9c7fd1f2d36618a76d8e411ee81d43015ada72e231R132-R135) [[5]](diffhunk://#diff-27c6488a232eee927f03ca9c7fd1f2d36618a76d8e411ee81d43015ada72e231L149-R150) [[6]](diffhunk://#diff-2f0b44442b5991ef916dda0e3338b0bc1aa66f3846dba9f797d09c068e647fa6R87) [[7]](diffhunk://#diff-2f0b44442b5991ef916dda0e3338b0bc1aa66f3846dba9f797d09c068e647fa6L128-R129) [[8]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfR575) [[9]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL584-R585) [[10]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL596-R597) [[11]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfR803-R806) [[12]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL819-R821) [[13]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfR976) [[14]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL1014-R1017)

* Refactored string copying in data structures to use a source pointer (`src_string`) and a single for-loop with an explicit size variable, improving readability and consistency. [[1]](diffhunk://#diff-27c6488a232eee927f03ca9c7fd1f2d36618a76d8e411ee81d43015ada72e231L206-R210) [[2]](diffhunk://#diff-2f0b44442b5991ef916dda0e3338b0bc1aa66f3846dba9f797d09c068e647fa6L182-R186) [[3]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL874-R879) [[4]](diffhunk://#diff-e881ad9e76e88196c668deb281fdf132420caee4c98408b9fe0da7ad201e67cfL1067-R1073)

These changes are mirrored in the single-header version to ensure consistency between the header-only and multi-file builds.