### PR TITLE
Add portable C++14 support

### DIFF
--- a/.github/scripts/build_and_test.sh
+++ b/.github/scripts/build_and_test.sh
@@ -15,8 +15,8 @@ for CONFIG in Debug Release; do
   DIR="build-cpp${STD}-${CONFIG}"
   cmake -B "$DIR" -G Ninja $FLAGS -DCMAKE_BUILD_TYPE=$CONFIG -DENCHANTUM_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=$STD
   if [[ "$STD" == "14" ]]; then
-    cmake --build "$DIR" --target tests_cpp14 tests_cpp14_single_header
-    ctest --test-dir "$DIR" -R 'tests_cpp14|tests_cpp14_single_header' --output-on-failure
+    cmake --build "$DIR" --target tests_cpp14_full tests_cpp14 tests_cpp14_single_header
+    ctest --test-dir "$DIR" -R '^(cpp14_full::|tests_cpp14$|tests_cpp14_single_header$)' --output-on-failure
   else
     cmake --build "$DIR"
     ctest --test-dir "$DIR" --output-on-failure

--- a/.github/scripts/build_and_test.sh
+++ b/.github/scripts/build_and_test.sh
@@ -14,6 +14,11 @@ FLAGS="$@"
 for CONFIG in Debug Release; do
   DIR="build-cpp${STD}-${CONFIG}"
   cmake -B "$DIR" -G Ninja $FLAGS -DCMAKE_BUILD_TYPE=$CONFIG -DENCHANTUM_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=$STD
-  cmake --build "$DIR"
-  ctest --test-dir "$DIR" --output-on-failure
+  if [[ "$STD" == "14" ]]; then
+    cmake --build "$DIR" --target tests_cpp14 tests_cpp14_single_header
+    ctest --test-dir "$DIR" -R 'tests_cpp14|tests_cpp14_single_header' --output-on-failure
+  else
+    cmake --build "$DIR"
+    ctest --test-dir "$DIR" --output-on-failure
+  fi
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
         run: |
           chmod +x .github/scripts/build_and_test.sh
 
+      - name: Build (C++14)
+        run: |
+          .github/scripts/build_and_test.sh 14 "${{ matrix.platform.flags }}"
+
       - name: Build (C++17)
         run: |
           .github/scripts/build_and_test.sh 17 "${{ matrix.platform.flags }}"

--- a/.github/workflows/cpp14-regression.yml
+++ b/.github/workflows/cpp14-regression.yml
@@ -1,0 +1,175 @@
+name: C++14 Regression Checks
+
+on:
+  push:
+    branches: [ci/cpp14-regression-checks]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  compatibility:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu GCC Latest
+            os: ubuntu-latest
+            compiler: gcc
+            setup: gcc-14
+            flags: -DCMAKE_CXX_COMPILER=g++
+            cpp20: true
+          - name: Ubuntu Clang Latest
+            os: ubuntu-latest
+            compiler: clang
+            setup: llvm-18
+            flags: -DCMAKE_CXX_COMPILER=clang++
+            cpp20: true
+          - name: macOS Clang Latest
+            os: macos-latest
+            compiler: system
+            flags: -DCMAKE_CXX_COMPILER=clang++
+            cpp20: true
+          - name: Windows MSVC 2022
+            os: windows-2022
+            compiler: msvc
+            flags: ""
+            cpp20: true
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Setup MSVC Dev Command Prompt
+        if: matrix.compiler == 'msvc'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup GCC
+        if: matrix.compiler == 'gcc'
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.setup }}
+
+      - name: Setup Clang
+        if: matrix.compiler == 'clang'
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.setup }}
+
+      - name: Setup Build Script
+        run: chmod +x .github/scripts/build_and_test.sh
+
+      - name: Build (C++14)
+        run: .github/scripts/build_and_test.sh 14 "${{ matrix.flags }}"
+
+      - name: Build (C++17)
+        run: .github/scripts/build_and_test.sh 17 "${{ matrix.flags }}"
+
+      - name: Build (C++20)
+        if: matrix.cpp20
+        run: .github/scripts/build_and_test.sh 20 "${{ matrix.flags }}"
+
+  regression-timing:
+    name: Regression Timing (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu GCC 14
+            os: ubuntu-latest
+            compiler: gcc
+            setup: gcc-14
+            flags: -DCMAKE_CXX_COMPILER=g++
+          - name: Windows MSVC 2022
+            os: windows-2022
+            compiler: msvc
+            flags: ""
+
+    steps:
+      - name: Checkout Candidate
+        uses: actions/checkout@v4
+        with:
+          path: candidate
+
+      - name: Checkout Baseline
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: baseline
+
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Setup MSVC Dev Command Prompt
+        if: matrix.compiler == 'msvc'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup GCC
+        if: matrix.compiler == 'gcc'
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: ${{ matrix.setup }}
+
+      - name: Measure Build Times
+        run: |
+          set -euo pipefail
+
+          measure() {
+            local repo="$1"
+            local label="$2"
+            local std="$3"
+            local target="$4"
+            local dir="${repo}/build-timing-cpp${std}-${target}"
+
+            rm -rf "$dir"
+            local start end elapsed
+            start=$(date +%s)
+            cmake -S "$repo" -B "$dir" -G Ninja ${{ matrix.flags }} -DCMAKE_BUILD_TYPE=Release -DENCHANTUM_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD="$std" -DCMAKE_CXX_EXTENSIONS=OFF
+            cmake --build "$dir" --target "$target" --parallel 1
+            end=$(date +%s)
+            elapsed=$((end - start))
+            echo "${label},cpp${std},${target},${elapsed}" | tee -a timing.csv
+          }
+
+          echo "label,standard,target,seconds" > timing.csv
+          measure baseline baseline 17 tests
+          measure candidate candidate 17 tests
+          measure baseline baseline 20 tests
+          measure candidate candidate 20 tests
+
+          python3 - <<'PY'
+          import csv
+
+          rows = list(csv.DictReader(open('timing.csv', newline='')))
+          values = {(row['label'], row['standard'], row['target']): int(row['seconds']) for row in rows}
+
+          with open('timing-summary.md', 'w', newline='') as out:
+              out.write('| Standard | Target | Baseline Seconds | Candidate Seconds | Delta Seconds | Delta Percent |\n')
+              out.write('| --- | --- | ---: | ---: | ---: | ---: |\n')
+              for standard in ['cpp17', 'cpp20']:
+                  key_base = ('baseline', standard, 'tests')
+                  key_candidate = ('candidate', standard, 'tests')
+                  base = values[key_base]
+                  candidate = values[key_candidate]
+                  delta = candidate - base
+                  percent = (delta / base * 100.0) if base else 0.0
+                  out.write(f'| {standard} | tests | {base} | {candidate} | {delta:+d} | {percent:+.1f}% |\n')
+          PY
+
+          cat timing-summary.md
+
+      - name: Upload Timing Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: timing-${{ matrix.name }}
+          path: |
+            timing.csv
+            timing-summary.md

--- a/.github/workflows/cpp14-regression.yml
+++ b/.github/workflows/cpp14-regression.yml
@@ -2,7 +2,24 @@ name: C++14 Regression Checks
 
 on:
   push:
-    branches: [ci/cpp14-regression-checks]
+    branches: [main, ci/cpp14-regression-checks]
+    paths:
+      - '.github/scripts/build_and_test.sh'
+      - '.github/workflows/cpp14-regression.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'enchantum/**'
+      - 'single_include/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '.github/scripts/build_and_test.sh'
+      - '.github/workflows/cpp14-regression.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'enchantum/**'
+      - 'single_include/**'
+      - 'tests/**'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/cpp14-regression.yml
+++ b/.github/workflows/cpp14-regression.yml
@@ -2,7 +2,7 @@ name: C++14 Regression Checks
 
 on:
   push:
-    branches: [main, ci/cpp14-regression-checks]
+    branches: [main, feature/portable-cpp14-support]
     paths:
       - '.github/scripts/build_and_test.sh'
       - '.github/workflows/cpp14-regression.yml'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,27 @@ file(GLOB_RECURSE INCS "${INCDIR}/*.hpp")
 
 add_library(enchantum INTERFACE ${INCS})
 add_library(enchantum::enchantum ALIAS enchantum)
-target_compile_features(enchantum INTERFACE cxx_std_14)
- 
-target_include_directories(enchantum INTERFACE
+target_compile_features(enchantum INTERFACE cxx_std_17)
+
+add_library(enchantum_cxx14 INTERFACE ${INCS})
+add_library(enchantum::enchantum-cxx14 ALIAS enchantum_cxx14)
+set_target_properties(enchantum_cxx14 PROPERTIES EXPORT_NAME enchantum-cxx14)
+target_compile_features(enchantum_cxx14 INTERFACE cxx_std_14)
+
+foreach(enchantum_target enchantum enchantum_cxx14)
+target_include_directories(${enchantum_target} INTERFACE
     $<BUILD_INTERFACE:${INCDIR}>
     $<INSTALL_INTERFACE:include>
 )
+endforeach()
 
 option(ENCHANTUM_BUILD_TESTS "Enable tests for this `enchantum` library" OFF)
 option(ENCHANTUM_ENABLE_MSVC_SPEEDUP "Enable faster but not 100% accurate MSVC enum reflection." ON)
 option(ENCHANTUM_BUILD_BENCHMARKS "Enable compile time benchmarks `enchantum` library" OFF)
 
-target_compile_definitions(enchantum INTERFACE ENCHANTUM_ENABLE_MSVC_SPEEDUP=$<BOOL:${ENCHANTUM_ENABLE_MSVC_SPEEDUP}>)
+foreach(enchantum_target enchantum enchantum_cxx14)
+target_compile_definitions(${enchantum_target} INTERFACE ENCHANTUM_ENABLE_MSVC_SPEEDUP=$<BOOL:${ENCHANTUM_ENABLE_MSVC_SPEEDUP}>)
+endforeach()
 
 if(ENCHANTUM_BUILD_TESTS)
   enable_testing()
@@ -37,7 +46,7 @@ if(ENCHANTUM_BUILD_BENCHMARKS)
 endif()
 
 
-install(TARGETS enchantum
+install(TARGETS enchantum enchantum_cxx14
     EXPORT enchantumTargets
     COMPONENT enchantum
 )
@@ -78,7 +87,7 @@ install(FILES
 )
 
 export(
-    TARGETS enchantum
+    TARGETS enchantum enchantum_cxx14
     NAMESPACE enchantum::
     FILE "${CMAKE_CURRENT_BINARY_DIR}/enchantumTargets.cmake"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE INCS "${INCDIR}/*.hpp")
 
 add_library(enchantum INTERFACE ${INCS})
 add_library(enchantum::enchantum ALIAS enchantum)
-target_compile_features(enchantum INTERFACE cxx_std_17)
+target_compile_features(enchantum INTERFACE cxx_std_14)
  
 target_include_directories(enchantum INTERFACE
     $<BUILD_INTERFACE:${INCDIR}>

--- a/README.md
+++ b/README.md
@@ -336,3 +336,5 @@ The cmake file provides the target `enchantum::enchantum` since this library is 
 add_subdirectory("third_party/enchantum")
 target_link_libraries(your_executable enchantum::enchantum)
 ```
+
+`enchantum::enchantum` preserves the default C++17 compile feature for existing CMake consumers. C++14 users can opt in with `enchantum::enchantum-cxx14` after configuring `ENCHANTUM_ALIAS_OPTIONAL` and `ENCHANTUM_ALIAS_STRING_VIEW`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enchantum
 
-**Enchantum** (short for "enchant enum") is a modern **C++17** header-only library for **compile-time enum reflection**. It provides fast, lightweight access to enum values, names, and bitflags all without macros or boilerplate.
+**Enchantum** (short for "enchant enum") is a modern **C++14 and later** header-only library for **compile-time enum reflection**. It provides fast, lightweight access to enum values, names, and bitflags all without macros or boilerplate.
 
 > Every year, countless turtles perish due to the pollution caused by slow, bloated build times.  
  Save the turtles — and your compile times — by switching to enchantum!
@@ -55,6 +55,8 @@ Compiler Support: (Look at [CI](https://github.com/ZXShady/enchantum/actions))
   - Clang >= 8
   - MSVC >= 19.24 VS16.4 (lower verions tested through godbolt)
   - Resharper >= 2023
+
+C++14 support requires configuring `ENCHANTUM_ALIAS_OPTIONAL` and `ENCHANTUM_ALIAS_STRING_VIEW` to optional-compatible and string-view-compatible types. C++17 and later use `std::optional` and `std::string_view` by default.
 
 Tested through basic tests on godbolt since I could not install it on CI, so support for them may not be the best.
   - ICX >= 2021.1.2 (Tested through godbolt [test link](https://godbolt.org/z/5naTha56K))
@@ -168,7 +170,7 @@ There are several enum reflection libraries out there — so why choose **enchan
 - Macro-free (non intrusive).
 - No modifications needed for existing enums.
 - Allows specifying ranges for specific enums when needed.
-- Supports C++17.
+- Supports C++14 and later. C++14 users must provide `optional` and `string_view` aliases through `ENCHANTUM_CONFIG_FILE` because those types are standard only in C++17 and later.
 - Nicer compiler errors.
 - Supports wide strings.
 - Efficient executable binary size.

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ All non-`void` functions are `[[nodiscard]]` unless explicitly said otherwise.
 
 **Note**: Documentation Incomplete.
 
-*all the concepts are replaced by SFINAE equalivents when compiling in C++17 mode*
+*all the concepts are replaced by SFINAE equalivents when compiling in pre-C++20 modes*
 
 Quick Reference
 
@@ -66,9 +66,10 @@ Quick Reference
   - [ENCHANTUM_ASSERT](#enchantum_assert)
   - [ENCHANTUM_THROW](#enchantum_throw)
   - [ENCHANTUM_ENABLE_MSVC_SPEEDUP](#enchantum_enable_msvc_speedup)
-  - [ENCHANTUM_OPTIONAL](#enchantum_optional)
+  - [ENCHANTUM_ALIAS_OPTIONAL](#enchantum_alias_optional)
   - [ENCHANTUM_STRING](#enchantum_string)
-  - [ENCHANTUM_STRING_VIEW](#enchantum_string_view)
+  - [ENCHANTUM_ALIAS_STRING_VIEW](#enchantum_alias_string_view)
+  - [C++14 Alias Configuration](#c14-alias-configuration)
 
 # Concepts
 ## Enum
@@ -1705,15 +1706,15 @@ A boolean macro that speeds up msvc compile times but may cause issues with extr
 #endif
 ```
 
-### ENCHANTUM_OPTIONAL
+### ENCHANTUM_ALIAS_OPTIONAL
 
 - **Description**: 
 A macro for customizing the optional type used in the library it is by default `std::optional`
 ```cpp
 // in all headers
-#ifndef ENCHANTUM_OPTIONAL
+#ifndef ENCHANTUM_ALIAS_OPTIONAL
 #include <optional>
-#define ENCHANTUM_OPTIONAL using std::optional;
+#define ENCHANTUM_ALIAS_OPTIONAL template<typename T> using optional = std::optional<T>;
 #endif
 ```
 
@@ -1729,15 +1730,15 @@ A macro for customizing the string type used in the library it is by default `st
 #endif
 ```
 
-### ENCHANTUM_STRING_VIEW
+### ENCHANTUM_ALIAS_STRING_VIEW
 
 - **Description**: 
 A macro for customizing the string view type used in the library it is by default `std::string_view`
 ```cpp
 // in all headers
-#ifndef ENCHANTUM_STRING_VIEW
+#ifndef ENCHANTUM_ALIAS_STRING_VIEW
 #include <string_view>
-#define ENCHANTUM_STRING_VIEW using std::string_view;
+#define ENCHANTUM_ALIAS_STRING_VIEW using string_view = std::string_view;
 #endif
 ```
 
@@ -1765,7 +1766,20 @@ where `my_enchantum_config.hpp` is
 
 ```cpp
 #include "my_optional.hpp"
-#define  ENCHANTUM_OPTIONAL template<typename T> using optional = my_optional<T>;
+#define ENCHANTUM_ALIAS_OPTIONAL template<typename T> using optional = my_optional<T>;
 #include "my_string.hpp"
-#define  ENCHANTUM_STRING using string = my_string;
+#define ENCHANTUM_ALIAS_STRING using string = my_string;
 ```
+
+### C++14 Alias Configuration
+
+C++14 does not provide `std::optional` or `std::string_view`. To use enchantum in C++14 mode, provide aliases through `ENCHANTUM_CONFIG_FILE`:
+
+```cpp
+#define ENCHANTUM_ALIAS_STRING_VIEW using string_view = my_string_view;
+#define ENCHANTUM_ALIAS_OPTIONAL \
+  template<typename T>           \
+  using optional = my_optional<T>;
+```
+
+The string-view replacement must provide `data()`, `size()`, `empty()`, `operator[]`, `find`, `rfind`, `substr`, `remove_prefix`, and `remove_suffix`. The optional replacement must provide default construction, construction from a value, boolean conversion, `has_value()`, and dereference.

--- a/enchantum/include/enchantum/algorithms.hpp
+++ b/enchantum/include/enchantum/algorithms.hpp
@@ -69,8 +69,12 @@ namespace details {
   template<typename E, typename Func, std::size_t... I>
   constexpr void for_each(Func& f, std::index_sequence<I...>)
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    ((void)f(std::integral_constant<E, values<E>[I]>{}), ...);
+#else
     using expander = int[];
     (void)expander{0, ((void)f(std::integral_constant<E, values<E>[I]> {}), 0)...};
+#endif
   }
 
 } // namespace details

--- a/enchantum/include/enchantum/algorithms.hpp
+++ b/enchantum/include/enchantum/algorithms.hpp
@@ -67,10 +67,10 @@ constexpr auto visit(Func func, Enums... enums) noexcept(noexcept(std::declval<F
 namespace details {
 
   template<typename E, typename Func, std::size_t... I>
-  constexpr auto for_each(Func& f, std::index_sequence<I...>)
+  constexpr void for_each(Func& f, std::index_sequence<I...>)
   {
-    // Clang 13 to 15 says ths syntax is invalid if I dont put more `()`
-    (void)((f(std::integral_constant<E, values<E>[I]> {}), ...));
+    using expander = int[];
+    (void)expander{0, ((void)f(std::integral_constant<E, values<E>[I]> {}), 0)...};
   }
 
 } // namespace details

--- a/enchantum/include/enchantum/algorithms.hpp
+++ b/enchantum/include/enchantum/algorithms.hpp
@@ -44,7 +44,7 @@ namespace details {
 #if 0
 template<Enum E, std::invocable<E> Func>
 constexpr auto visit(Func func, E e) 
-noexcept(std::is_nothrow_invocable_v<Func, E>)
+noexcept(noexcept(std::declval<Func>()(std::declval<E>())))
 {
   using Ret = decltype(func(e));
   
@@ -55,7 +55,7 @@ noexcept(std::is_nothrow_invocable_v<Func, E>)
   }(std::make_index_sequence<count<E>>());
 }
 template<Enum... Enums, std::invocable<Enums...> Func>
-constexpr auto visit(Func func, Enums... enums) noexcept(std::is_nothrow_invocable_v<Func, Enums...>)
+constexpr auto visit(Func func, Enums... enums) noexcept(noexcept(std::declval<Func>()(std::declval<Enums>()...)))
 {
   using Ret = decltype(func(enums...));
   return [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {

--- a/enchantum/include/enchantum/array.hpp
+++ b/enchantum/include/enchantum/array.hpp
@@ -8,7 +8,7 @@ namespace enchantum {
 
 template<typename E, typename V, typename Container = std::array<V, count<E>>>
 class array : public Container {
-  static_assert(std::is_enum<E>::value);
+  static_assert(std::is_enum<E>::value, "enchantum::array requires an enum type");
 public:
   using container_type = Container;
   using index_type     = E;

--- a/enchantum/include/enchantum/array.hpp
+++ b/enchantum/include/enchantum/array.hpp
@@ -8,7 +8,7 @@ namespace enchantum {
 
 template<typename E, typename V, typename Container = std::array<V, count<E>>>
 class array : public Container {
-  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_enum<E>::value);
 public:
   using container_type = Container;
   using index_type     = E;

--- a/enchantum/include/enchantum/array.hpp
+++ b/enchantum/include/enchantum/array.hpp
@@ -18,26 +18,26 @@ public:
   using Container::at;
   using Container::operator[];
 
-  [[nodiscard]] constexpr reference at(const E index)
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference at(const E index)
   {
     if (const auto i = enchantum::enum_to_index(index))
       return operator[](*i);
     ENCHANTUM_THROW(std::out_of_range("enchantum::array::at index out of range"), index);
   }
 
-  [[nodiscard]] constexpr const_reference at(const E index) const
+  ENCHANTUM_DETAILS_NODISCARD constexpr const_reference at(const E index) const
   {
     if (const auto i = enchantum::enum_to_index(index))
       return operator[](*i);
     ENCHANTUM_THROW(std::out_of_range("enchantum::array::at: index out of range"), index);
   }
 
-  [[nodiscard]] constexpr reference operator[](const E index) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference operator[](const E index) noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
 
-  [[nodiscard]] constexpr const_reference operator[](const E index) const noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr const_reference operator[](const E index) const noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }

--- a/enchantum/include/enchantum/bitflags.hpp
+++ b/enchantum/include/enchantum/bitflags.hpp
@@ -25,7 +25,7 @@ namespace details {
   template<typename E>
   constexpr E value_ors_impl()
   {
-    static_assert(is_bitflag<E>, "");
+    static_assert(is_bitflag<E>, "enchantum::value_ors requires a bitflag enum (is_bitflag<E> must be true)");
     using T = std::underlying_type_t<E>;
     T ret{};
     for (std::size_t i = 0; i < count<E>; ++i)

--- a/enchantum/include/enchantum/bitflags.hpp
+++ b/enchantum/include/enchantum/bitflags.hpp
@@ -17,21 +17,31 @@
 
 namespace enchantum {
 
+namespace details {
+  struct equal_to_string_view {
+    constexpr bool operator()(const string_view a, const string_view b) const noexcept { return a == b; }
+  };
+
+  template<typename E>
+  constexpr E value_ors_impl()
+  {
+    static_assert(is_bitflag<E>, "");
+    using T = std::underlying_type_t<E>;
+    T ret{};
+    for (const auto val : values_generator<E>)
+      ret |= static_cast<T>(val);
+    return static_cast<E>(ret);
+  }
+} // namespace details
+
 template<typename E>
-inline constexpr E value_ors = [] {
-  static_assert(is_bitflag<E>, "");
-  using T = std::underlying_type_t<E>;
-  T ret{};
-  for (const auto val : values_generator<E>)
-    ret |= static_cast<T>(val);
-  return static_cast<E>(ret);
-}();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr E value_ors = details::value_ors_impl<E>();
 
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
 {
-  if constexpr (!has_zero_flag<E>)
+  if (!has_zero_flag<E>)
     if (value == 0)
       return false;
 
@@ -74,19 +84,19 @@ template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
 {
   using T = std::underlying_type_t<E>;
-  if constexpr (has_zero_flag<E>)
+  if (has_zero_flag<E>)
     if (static_cast<T>(value) == 0)
-      return String(names_generator<E>[0]);
+      return String(names_generator<E>[0].data(), names_generator<E>[0].size());
 
   String name;
   T      check_value = 0;
-  for (auto i = std::size_t{has_zero_flag<E>}; i < count<E>; ++i) {
+  for (auto i = static_cast<std::size_t>(has_zero_flag<E>); i < count<E>; ++i) {
     const auto v = static_cast<T>(values_generator<E>[i]);
     if (v == (static_cast<T>(value) & v)) {
       const auto s = names_generator<E>[i];
       if (!name.empty())
         name.append(1, sep);           // append separator if not the first value
-      name.append(s.data(), s.size()); // not using operator += since this may not be std::string_view always
+      name.append(s.data(), s.size());
       check_value |= v;
     }
   }
@@ -117,7 +127,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
 {
-  return enchantum::cast_bitflag<E>(s, sep, [](const auto& a, const auto& b) { return a == b; });
+  return enchantum::cast_bitflag<E>(s, sep, details::equal_to_string_view{});
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>

--- a/enchantum/include/enchantum/bitflags.hpp
+++ b/enchantum/include/enchantum/bitflags.hpp
@@ -28,8 +28,8 @@ namespace details {
     static_assert(is_bitflag<E>, "");
     using T = std::underlying_type_t<E>;
     T ret{};
-    for (const auto val : values_generator<E>)
-      ret |= static_cast<T>(val);
+    for (std::size_t i = 0; i < count<E>; ++i)
+      ret |= static_cast<T>(values_generator<E>[i]);
     return static_cast<E>(ret);
   }
 } // namespace details

--- a/enchantum/include/enchantum/bitflags.hpp
+++ b/enchantum/include/enchantum/bitflags.hpp
@@ -39,7 +39,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr E value_ors = details::value_ors_impl<E>(
 
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
 {
   if (!has_zero_flag<E>)
     if (value == 0)
@@ -49,13 +49,13 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const E value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const E value) noexcept
 {
   return enchantum::contains_bitflag<E>(static_cast<std::underlying_type_t<E>>(value));
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
 {
   std::size_t pos = 0;
   for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -68,7 +68,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
 {
   std::size_t pos = 0;
   for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -81,7 +81,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 
 
 template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
+ENCHANTUM_DETAILS_NODISCARD constexpr String to_string_bitflag(const E value, const char sep = '|')
 {
   using T = std::underlying_type_t<E>;
   if (has_zero_flag<E>)
@@ -106,7 +106,7 @@ template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
 {
   using T = std::underlying_type_t<E>;
   T           check_value{};
@@ -125,13 +125,13 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
 {
   return enchantum::cast_bitflag<E>(s, sep, details::equal_to_string_view{});
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const std::underlying_type_t<E> value) noexcept
 {
   return enchantum::contains_bitflag<E>(value) ? optional<E>(static_cast<E>(value)) : optional<E>();
 }

--- a/enchantum/include/enchantum/bitset.hpp
+++ b/enchantum/include/enchantum/bitset.hpp
@@ -19,7 +19,7 @@ namespace details {
 
 template<typename E, typename Container = details::bitset<count<E>>>
 class bitset : public Container {
-  static_assert(std::is_enum<E>::value);
+  static_assert(std::is_enum<E>::value, "enchantum::bitset requires an enum type");
 public:
 
   using container_type = Container;

--- a/enchantum/include/enchantum/bitset.hpp
+++ b/enchantum/include/enchantum/bitset.hpp
@@ -34,6 +34,8 @@ public:
   using Container::Container;
   using Container::operator=;
 
+  constexpr bitset() = default;
+
   [[nodiscard]] string to_string(const char sep = '|') const
   {
     string name;

--- a/enchantum/include/enchantum/bitset.hpp
+++ b/enchantum/include/enchantum/bitset.hpp
@@ -19,7 +19,7 @@ namespace details {
 
 template<typename E, typename Container = details::bitset<count<E>>>
 class bitset : public Container {
-  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_enum<E>::value);
 public:
 
   using container_type = Container;
@@ -42,7 +42,7 @@ public:
         const auto s = enchantum::names_generator<E>[i];
         if (!name.empty())
           name += sep;
-        name.append(s.data(), s.size()); // not using operator += since this may not be std::string_view always
+        name.append(s.data(), s.size());
       }
     }
     return name;

--- a/enchantum/include/enchantum/bitset.hpp
+++ b/enchantum/include/enchantum/bitset.hpp
@@ -36,7 +36,7 @@ public:
 
   constexpr bitset() = default;
 
-  [[nodiscard]] string to_string(const char sep = '|') const
+  ENCHANTUM_DETAILS_NODISCARD string to_string(const char sep = '|') const
   {
     string name;
     for (std::size_t i = 0; i < enchantum::count<E>; ++i) {
@@ -50,7 +50,7 @@ public:
     return name;
   }
 
-  [[nodiscard]] constexpr auto to_string(const char zero, const char one) const
+  ENCHANTUM_DETAILS_NODISCARD constexpr auto to_string(const char zero, const char one) const
   {
     return Container::to_string(zero, one);
   }
@@ -62,12 +62,12 @@ public:
     }
   }
 
-  [[nodiscard]] constexpr reference operator[](const E index) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference operator[](const E index) noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
 
-  [[nodiscard]] constexpr bool operator[](const E index) const noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool operator[](const E index) const noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }

--- a/enchantum/include/enchantum/bitwise_operators.hpp
+++ b/enchantum/include/enchantum/bitwise_operators.hpp
@@ -20,27 +20,27 @@ namespace enchantum {
 namespace bitwise_operators {
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator~(E e) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator~(E e) noexcept
   {
     return static_cast<E>(~static_cast<std::underlying_type_t<E>>(e));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator|(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator|(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) | static_cast<T>(b));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator&(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator&(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) & static_cast<T>(b));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator^(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator^(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) ^ static_cast<T>(b));
@@ -71,17 +71,17 @@ namespace bitwise_operators {
 } // namespace enchantum
 
 #define ENCHANTUM_DEFINE_BITWISE_FOR(Enum)                                                \
-  [[nodiscard]] constexpr Enum operator&(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator&(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) & static_cast<T>(b));                      \
   }                                                                                       \
-  [[nodiscard]] constexpr Enum operator|(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator|(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) | static_cast<T>(b));                      \
   }                                                                                       \
-  [[nodiscard]] constexpr Enum operator^(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator^(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) ^ static_cast<T>(b));                      \
@@ -89,7 +89,7 @@ namespace bitwise_operators {
   constexpr Enum&              operator&=(Enum& a, Enum b) noexcept { return a = a & b; } \
   constexpr Enum&              operator|=(Enum& a, Enum b) noexcept { return a = a | b; } \
   constexpr Enum&              operator^=(Enum& a, Enum b) noexcept { return a = a ^ b; } \
-  [[nodiscard]] constexpr Enum operator~(Enum a) noexcept                                 \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator~(Enum a) noexcept                                 \
   {                                                                                       \
     return static_cast<Enum>(~static_cast<std::underlying_type_t<Enum>>(a));              \
   }

--- a/enchantum/include/enchantum/common.hpp
+++ b/enchantum/include/enchantum/common.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "details/compat.hpp"
 #ifdef __cpp_concepts
   #include <concepts>
 #endif
@@ -27,29 +28,29 @@
 
 namespace enchantum {
 
-template<typename T, bool = std::is_enum_v<T>>
-inline constexpr bool is_scoped_enum = false;
+template<typename T, bool = std::is_enum<T>::value>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_scoped_enum = false;
 
 template<typename E>
-inline constexpr bool is_scoped_enum<E, true> = !std::is_convertible_v<E, std::underlying_type_t<E>>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_scoped_enum<E, true> = !std::is_convertible<E, std::underlying_type_t<E>>::value;
 
 template<typename E>
-inline constexpr bool is_unscoped_enum = std::is_enum_v<E> && !is_scoped_enum<E>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_unscoped_enum = std::is_enum<E>::value && !is_scoped_enum<E>;
 
 template<typename E, typename = void>
-inline constexpr bool has_fixed_underlying_type = false;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_fixed_underlying_type = false;
 
 template<typename E>
-inline constexpr bool has_fixed_underlying_type<E, decltype(void(E{0}))> = std::is_enum_v<E>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_fixed_underlying_type<E, decltype(void(E{0}))> = std::is_enum<E>::value;
 
 
 #ifdef __cpp_concepts
 
 template<typename T>
-concept Enum = std::is_enum_v<T>;
+concept Enum = std::is_enum<T>::value;
 
 template<Enum E>
-inline constexpr bool is_bitflag = requires(E e) {
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag = requires(E e) {
   requires std::same_as<decltype(e & e), bool> || std::same_as<decltype(e & e), E>;
   { ~e } -> std::same_as<E>;
   { e | e } -> std::same_as<E>;
@@ -65,7 +66,7 @@ template<typename T>
 concept UnsignedEnum = Enum<T> && !SignedEnum<T>;
 
 template<typename T>
-concept ScopedEnum = Enum<T> && (!std::is_convertible_v<T, std::underlying_type_t<T>>);
+concept ScopedEnum = Enum<T> && (!std::is_convertible<T, std::underlying_type_t<T>>::value);
 
 template<typename T>
 concept UnscopedEnum = Enum<T> && !ScopedEnum<T>;
@@ -83,23 +84,23 @@ concept EnumFixedUnderlying = Enum<T> && requires { T{0}; };
 
 
 template<typename E, typename = void>
-inline constexpr bool is_bitflag = false;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag = false;
 
 // clang-format off
 template<typename E>
-inline constexpr bool is_bitflag<E, 
-    std::void_t<
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag<E,
+    enchantum::details::void_t<
     decltype(E{} & E{}),
-    decltype(~E{}), 
-    decltype(E{} | E{}), 
-    decltype(std::declval<E&>() &= E{}), 
+    decltype(~E{}),
+    decltype(E{} | E{}),
+    decltype(std::declval<E&>() &= E{}),
     decltype(std::declval<E&>() |= E{})
-    >> =  std::is_enum_v<E>
-    &&    (std::is_same_v<decltype(E{} & E{}),bool>  || std::is_same_v<decltype(E{} & E{}), E>) 
-    &&    std::is_same_v<decltype(~E{}), E> 
-    &&    std::is_same_v<decltype(E{} | E{}), E>
-    &&    std::is_same_v<decltype(std::declval<E&>() &= E{}), E&>
-    &&    std::is_same_v<decltype(std::declval<E&>() |= E{}), E&>
+    >> =  std::is_enum<E>::value
+    &&    (std::is_same<decltype(E{} & E{}),bool>::value  || std::is_same<decltype(E{} & E{}), E>::value)
+    &&    std::is_same<decltype(~E{}), E>::value
+    &&    std::is_same<decltype(E{} | E{}), E>::value
+    &&    std::is_same<decltype(std::declval<E&>() &= E{}), E&>::value
+    &&    std::is_same<decltype(std::declval<E&>() |= E{}), E&>::value
     ;
 // clang-format on
 #endif
@@ -109,19 +110,37 @@ namespace details {
   template<typename T, typename U>
   constexpr auto Max(T a, U b)
   {
-    return a < b ? b : a;
+    using R = typename std::common_type<T, U>::type;
+    return static_cast<R>(a) < static_cast<R>(b) ? static_cast<R>(b) : static_cast<R>(a);
   }
   template<typename T, typename U>
   constexpr auto Min(T a, U b)
   {
-    return a > b ? b : a;
+    using R = typename std::common_type<T, U>::type;
+    return static_cast<R>(a) > static_cast<R>(b) ? static_cast<R>(b) : static_cast<R>(a);
   }
-#if !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
   template<typename E, auto V, typename = void>
-  inline constexpr bool is_valid_cast = false;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_valid_cast = false;
 
   template<typename E, auto V>
-  inline constexpr bool is_valid_cast<E, V, std::void_t<std::integral_constant<E, static_cast<E>(V)>>> = true;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_valid_cast<E, V, enchantum::details::void_t<std::integral_constant<E, static_cast<E>(V)>>> = true;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  constexpr auto valid_cast_range_recurse() noexcept;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range, bool IsValid>
+  struct valid_cast_range_recurse_impl;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  struct valid_cast_range_recurse_impl<E, range, old_range, true> {
+    static constexpr auto value() noexcept { return valid_cast_range_recurse<E, range * 2, range>(); }
+  };
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  struct valid_cast_range_recurse_impl<E, range, old_range, false> {
+    static constexpr auto value() noexcept { return old_range > 0 ? old_range * 2 - 1 : old_range; }
+  };
 
   template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
   constexpr auto valid_cast_range_recurse() noexcept
@@ -134,55 +153,86 @@ namespace details {
     // while clang makes it a subsituation failure which we can check for
     // using std::inegral_constant makes sure this is a constant expression situation
     // for SFINAE to occur
-    if constexpr (is_valid_cast<E, range>)
-      return valid_cast_range_recurse<E, range * 2, range>();
-    else
-      return old_range > 0 ? old_range * 2 - 1 : old_range;
+    return valid_cast_range_recurse_impl<E, range, old_range, is_valid_cast<E, range>>::value();
   }
+
   template<typename E, int max_range>
-  constexpr auto valid_cast_range() noexcept
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, 0>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    return T{0};
+  }
+
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, 1>) noexcept
   {
     using T = std::underlying_type_t<E>;
     using L = std::numeric_limits<T>;
+    return is_valid_cast<E, (L::max)()> ? L::max() : details::valid_cast_range_recurse<E, max_range, 0>();
+  }
 
-    if constexpr (max_range == 0)
-      return T{0};
-    else if constexpr (max_range > 0 && is_valid_cast<E, (L::max)()>)
-      return L::max();
-    else if constexpr (max_range < 0 && is_valid_cast<E, (L::min)()>)
-      return L::min();
-    else
-      return details::valid_cast_range_recurse<E, max_range, 0>();
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, -1>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+    return is_valid_cast<E, (L::min)()> ? L::min() : details::valid_cast_range_recurse<E, max_range, 0>();
+  }
+
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range() noexcept
+  {
+    return details::valid_cast_range_impl<E, max_range>(std::integral_constant<int, (max_range > 0) - (max_range < 0)>{});
   }
 
 #endif
 
   template<typename E>
+  constexpr auto enum_range_of_bool(const int max_range, std::true_type)
+  {
+    return max_range > 0;
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_signed(const int max_range, std::true_type)
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+    constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
+    constexpr auto Min = has_fixed_underlying_type<E> ? (L::min)() : details::valid_cast_range<E, -1>();
+#else
+    constexpr auto Max = (L::max)();
+    constexpr auto Min = (L::min)();
+#endif
+    return max_range > 0 ? details::Min(ENCHANTUM_MAX_RANGE, Max) : details::Max(ENCHANTUM_MIN_RANGE, Min);
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_signed(const int max_range, std::false_type)
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+    constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
+#else
+    constexpr auto Max = (L::max)();
+#endif
+    return max_range > 0 ? details::Min(static_cast<unsigned int>(ENCHANTUM_MAX_RANGE), Max) : 0;
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_bool(const int max_range, std::false_type)
+  {
+    using T = std::underlying_type_t<E>;
+    return enum_range_of_signed<E>(max_range, std::integral_constant<bool, std::is_signed<T>::value>{});
+  }
+
+  template<typename E>
   constexpr auto enum_range_of(const int max_range)
   {
     using T = std::underlying_type_t<E>;
-    if constexpr (std::is_same_v<bool, T>) {
-      return max_range > 0;
-    }
-    else {
-      using L = std::numeric_limits<T>;
-#if !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
-      constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
-      constexpr auto Min = has_fixed_underlying_type<E>
-        ? (L::min)()
-        : details::valid_cast_range<E, std::is_signed_v<T> ? -1 : 0>();
-#else
-      constexpr auto Max = (L::max)();
-      constexpr auto Min = (L::min)();
-#endif
-      (void)Min; // Only used in signed branch
-      if constexpr (std::is_signed_v<T>) {
-        return max_range > 0 ? details::Min(ENCHANTUM_MAX_RANGE, Max) : details::Max(ENCHANTUM_MIN_RANGE, Min);
-      }
-      else {
-        return max_range > 0 ? details::Min(static_cast<unsigned int>(ENCHANTUM_MAX_RANGE), Max) : 0;
-      }
-    }
+    return enum_range_of_bool<E>(max_range, std::is_same<bool, T>{});
   }
 } // namespace details
 
@@ -199,9 +249,9 @@ public:
 
 namespace details {
   template<typename T,typename = void>
-  inline constexpr bool has_specialized_traits = true;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_specialized_traits = true;
   template<typename T>
-  inline constexpr bool has_specialized_traits<T, typename enum_traits<T>::zxshady_enchantum_is_not_specialized_tag> = false;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_specialized_traits<T, typename enum_traits<T>::zxshady_enchantum_is_not_specialized_tag> = false;
 
 } // namespace details
 
@@ -211,6 +261,6 @@ namespace details {
   #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         Enum Name
   #define ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(Name) BitFlagEnum Name
 #else
-  #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         typename Name, std::enable_if_t<std::is_enum_v<Name>, int> = 0
+  #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         typename Name, std::enable_if_t<std::is_enum<Name>::value, int> = 0
   #define ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(Name) typename Name, std::enable_if_t<is_bitflag<Name>, int> = 0
 #endif

--- a/enchantum/include/enchantum/details/compat.hpp
+++ b/enchantum/include/enchantum/details/compat.hpp
@@ -49,6 +49,7 @@ struct type_identity {
   using type = T;
 };
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
 template<typename T, std::size_t N>
 struct cxx14_array {
   T elems[N == 0 ? 1 : N]{};
@@ -74,6 +75,7 @@ struct cxx14_array {
   constexpr std::size_t size() const noexcept { return N; }
   constexpr bool        empty() const noexcept { return N == 0; }
 };
+#endif
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
 template<typename T, std::size_t N>

--- a/enchantum/include/enchantum/details/compat.hpp
+++ b/enchantum/include/enchantum/details/compat.hpp
@@ -70,6 +70,7 @@ struct cxx14_array {
   constexpr const T* end() const noexcept { return elems + N; }
 
   constexpr std::size_t size() const noexcept { return N; }
+  constexpr bool        empty() const noexcept { return N == 0; }
 };
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L

--- a/enchantum/include/enchantum/details/compat.hpp
+++ b/enchantum/include/enchantum/details/compat.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+#include <cstddef>
+
+#if defined(_MSVC_LANG)
+  #define ENCHANTUM_DETAILS_CXX_STD _MSVC_LANG
+#else
+  #define ENCHANTUM_DETAILS_CXX_STD __cplusplus
+#endif
+
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  #include <array>
+#endif
+
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  #define ENCHANTUM_DETAILS_INLINE_VAR inline
+#else
+  #define ENCHANTUM_DETAILS_INLINE_VAR
+#endif
+
+namespace enchantum {
+namespace details {
+
+template<typename...>
+using void_t = void;
+
+template<bool B>
+using bool_constant = std::integral_constant<bool, B>;
+
+template<typename F, typename... Args>
+struct is_invocable {
+private:
+  template<typename U>
+  static auto test(int) -> decltype(std::declval<U>()(std::declval<Args>()...), std::true_type{});
+
+  template<typename>
+  static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<F>(0))::value;
+};
+
+template<typename T>
+struct type_identity {
+  using type = T;
+};
+
+template<typename T, std::size_t N>
+struct cxx14_array {
+  T elems[N == 0 ? 1 : N]{};
+
+  constexpr T*       data() noexcept { return elems; }
+  constexpr const T* data() const noexcept { return elems; }
+
+  constexpr T&       operator[](std::size_t i) noexcept { return elems[i]; }
+  constexpr const T& operator[](std::size_t i) const noexcept { return elems[i]; }
+
+  constexpr T&       front() noexcept { return elems[0]; }
+  constexpr const T& front() const noexcept { return elems[0]; }
+
+  constexpr T&       back() noexcept { return elems[N == 0 ? 0 : N - 1]; }
+  constexpr const T& back() const noexcept { return elems[N == 0 ? 0 : N - 1]; }
+
+  constexpr T*       begin() noexcept { return elems; }
+  constexpr const T* begin() const noexcept { return elems; }
+
+  constexpr T*       end() noexcept { return elems + N; }
+  constexpr const T* end() const noexcept { return elems + N; }
+
+  constexpr std::size_t size() const noexcept { return N; }
+};
+
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+template<typename T, std::size_t N>
+using array = std::array<T, N>;
+#else
+template<typename T, std::size_t N>
+using array = cxx14_array<T, N>;
+#endif
+
+} // namespace details
+} // namespace enchantum

--- a/enchantum/include/enchantum/details/compat.hpp
+++ b/enchantum/include/enchantum/details/compat.hpp
@@ -16,8 +16,10 @@
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
   #define ENCHANTUM_DETAILS_INLINE_VAR inline
+  #define ENCHANTUM_DETAILS_NODISCARD [[nodiscard]]
 #else
   #define ENCHANTUM_DETAILS_INLINE_VAR
+  #define ENCHANTUM_DETAILS_NODISCARD
 #endif
 
 namespace enchantum {

--- a/enchantum/include/enchantum/details/enchantum_clang.hpp
+++ b/enchantum/include/enchantum/details/enchantum_clang.hpp
@@ -36,6 +36,7 @@ namespace details {
 
 #define SZC(x) (sizeof(x) - 1)
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_clang_values_pack(const char* s) noexcept
   {
     for (std::size_t i = 0; true; ++i) {
@@ -50,6 +51,14 @@ namespace details {
     // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
     return details::find_clang_values_pack(__PRETTY_FUNCTION__);
   }
+#else
+  template<auto... Vs>
+  constexpr auto var_name() noexcept
+  {
+    // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
+    return __PRETTY_FUNCTION__ + SZC("auto enchantum::details::var_name() [Vs = <");
+  }
+#endif
 
 
   constexpr bool is_out_of_range_parse(
@@ -123,13 +132,21 @@ namespace details {
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::true_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(false), static_cast<E>(Underlying(1) << Is)..., 0>();
+#else
     return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+#endif
   }
 
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::false_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
   }
 
   template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
@@ -193,7 +210,11 @@ namespace details {
   constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
   {
     constexpr auto ArraySize = sizeof...(Is);
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    const auto     str       = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     const auto     str       = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
 
     constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
     constexpr auto enum_in_array_len  = enum_in_array_name.size();

--- a/enchantum/include/enchantum/details/enchantum_clang.hpp
+++ b/enchantum/include/enchantum/details/enchantum_clang.hpp
@@ -14,7 +14,6 @@
 #include "../type_name.hpp"
 #include "shared.hpp"
 #include "string_view.hpp"
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -29,18 +28,27 @@ namespace details {
     if (is_scoped_enum)
       return raw_type_name;
 
-    if (const auto pos = raw_type_name.rfind(':'); pos != string_view::npos)
+    const auto pos = raw_type_name.rfind(':');
+    if (pos != string_view::npos)
       return raw_type_name.substr(0, pos - 1);
     return string_view();
   }
 
 #define SZC(x) (sizeof(x) - 1)
 
-  template<auto... Vs>
+  constexpr const char* find_clang_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == 's' && s[i + 2] == ' ' && s[i + 3] == '=' && s[i + 4] == ' ' && s[i + 5] == '<')
+        return s + i + SZC("Vs = <");
+    }
+  }
+
+  template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
     // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
-    return __PRETTY_FUNCTION__ + SZC("auto enchantum::details::var_name() [Vs = <");
+    return details::find_clang_values_pack(__PRETTY_FUNCTION__);
   }
 
 
@@ -100,7 +108,7 @@ namespace details {
       else {
         str += least_length_when_value;
         const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
-        if constexpr (IsBitFlag)
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
@@ -112,61 +120,66 @@ namespace details {
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
+  {
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    using T          = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
+
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    const auto     str       = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+
+    constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
+    constexpr auto enum_in_array_len  = enum_in_array_name.size();
+    // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+
+    // ((anonymous namespace)::A)0
+    // (anonymous namespace)::a
+    // this is needed to determine whether the above are cast expression if 2 braces are
+    // next to eachother then it is a cast but only for anonymoused namespaced enums
+    constexpr std::size_t index_check = enum_in_array_name.size() != 0 && enum_in_array_name[0] == '(' ? 1 : 0;
+
+    details::parse_string<is_bitflag<E>>(
+      /*index_check=*/index_check,
+      /*str = */ str,
+#if __clang_major__ > 12
+      /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
+#else
+      /*least_length_when_casting=*/1,
+#endif
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<T>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
   constexpr auto reflect(std::index_sequence<Is...>) noexcept
   {
-    using MinT       = decltype(Min);
-    using T          = std::underlying_type_t<E>;
-    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, T>, unsigned char, T>>;
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
 
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      const auto     str       = [](auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-        {
-          return details::var_name<static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        }
-        else {
-          return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-        }
-      }(0);
-
-      constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
-      constexpr auto enum_in_array_len  = enum_in_array_name.size();
-      // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-
-      // ((anonymous namespace)::A)0
-      // (anonymous namespace)::a
-      // this is needed to determine whether the above are cast expression if 2 braces are
-      // next to eachother then it is a cast but only for anonymoused namespaced enums
-      constexpr std::size_t index_check = enum_in_array_name.size() != 0 && enum_in_array_name[0] == '(' ? 1 : 0;
-
-      details::parse_string<is_bitflag<E>>(
-        /*index_check=*/index_check,
-        /*str = */ str,
-#if __clang_major__ > 12
-        /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
-#else
-        /*least_length_when_casting=*/1,
-#endif
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<T>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-
-      return ret;
-    }();
-
-    using Strings = std::array<char, elements_local.total_string_length>;
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
@@ -176,13 +189,11 @@ namespace details {
     return data;
   }
 
-  template<typename E, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
   constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
   {
-    using MinT       = decltype(Min);
-
     constexpr auto ArraySize = sizeof...(Is);
-    const auto     str       = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)...,0>();
+    const auto     str       = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
 
     constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
     constexpr auto enum_in_array_len  = enum_in_array_name.size();

--- a/enchantum/include/enchantum/details/enchantum_clang.hpp
+++ b/enchantum/include/enchantum/details/enchantum_clang.hpp
@@ -36,6 +36,13 @@ namespace details {
 
 #define SZC(x) (sizeof(x) - 1)
 
+  constexpr const char* find_comma(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i)
+      if (s[i] == ',')
+        return s + i;
+  }
+
 #if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_clang_values_pack(const char* s) noexcept
   {
@@ -77,7 +84,7 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = details::find_comma(str + least_length_when_casting) + SZC(", ");
       }
       else {
         return true;
@@ -112,11 +119,11 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = details::find_comma(str + least_length_when_casting) + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        const auto commapos = static_cast<std::size_t>(details::find_comma(str) - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -1,7 +1,6 @@
 #include "../common.hpp"
 #include "../type_name.hpp"
 #include "shared.hpp"
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -26,18 +25,18 @@ namespace details {
 
 
   // this is needed since gcc transforms "{anonymous}" into "<unnamed>" for values
-  template<auto Enum>
+  template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
     // constexpr auto f() [with auto _ = (
     //constexpr auto f() [with auto _ = (Scoped)0]
     auto s  = string_view(__PRETTY_FUNCTION__ +
-                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = "),
-                         SZC(__PRETTY_FUNCTION__) -
-                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = ]"));
-    using E = decltype(Enum);
+                            SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
+                          SZC(__PRETTY_FUNCTION__) -
+                            SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
+    s.remove_prefix(s.find(';') + SZC(" E Enum = "));
     // if scoped
-    if constexpr (!std::is_convertible_v<E, std::underlying_type_t<E>>) {
+    if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;
     }
     else {
@@ -45,21 +44,21 @@ namespace details {
         s.remove_prefix(SZC("("));
         s.remove_suffix(SZC(")0"));
       }
-      if (const auto pos = s.rfind(':'); pos != s.npos)
+      const auto pos = s.rfind(':');
+      if (pos != s.npos)
         return pos - 1;
       return std::size_t{0};
     }
   }
 
 #if __GNUC__ == 10
-  template<auto V>
+  template<typename E, E V>
   constexpr auto gcc10_workaround() noexcept
   {
-    using E               = decltype(V);
     using T               = std::underlying_type_t<E>;
-    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with auto V = ");
+    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with E = ");
     constexpr auto begin  = __PRETTY_FUNCTION__ + prefix;
-    if constexpr (begin[0] == '(') {
+    if (begin[0] == '(') {
       std::size_t i   = SZC(__PRETTY_FUNCTION__) - prefix - SZC("(");
       const char* end = __PRETTY_FUNCTION__ + SZC(__PRETTY_FUNCTION__) - 1;
       while (*end != ')') {
@@ -69,10 +68,11 @@ namespace details {
       --i;
       return i;
     }
-    else if constexpr (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
-      constexpr auto  s      = details::enum_in_array_name_size<E{}>();
+    else if (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
+      constexpr auto  s      = details::enum_in_array_name_size<E, E{}>();
       constexpr auto& tyname = raw_type_name<E>;
-      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+      const auto pos = tyname.rfind("::");
+      if (pos != tyname.npos) {
         return s + tyname.substr(pos).size();
       }
       else {
@@ -80,37 +80,50 @@ namespace details {
       }
     }
     else {
-      return details::gcc10_workaround<static_cast<E>(static_cast<T>(V) + 1)>();
+      return details::gcc10_workaround<E, static_cast<E>(static_cast<T>(V) + 1)>();
     }
   }
 #endif
 
   template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting_impl(std::true_type) noexcept
+  {
+    return details::enum_in_array_name_size<Enum, Enum{}>();
+  }
+
+  template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting_impl(std::false_type) noexcept
+  {
+#if __GNUC__ == 10
+    return details::gcc10_workaround<Enum, static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
+#else
+    constexpr auto  s      = details::enum_in_array_name_size<Enum, Enum{}>();
+    constexpr auto& tyname = raw_type_name<Enum>;
+    const auto pos = tyname.rfind("::");
+    if (pos != tyname.npos)
+      return s + tyname.substr(pos).size();
+    return s + tyname.size();
+#endif
+  }
+
+  template<typename Enum>
   constexpr auto length_of_enum_in_template_array_if_casting() noexcept
   {
-    if constexpr (is_scoped_enum<Enum>) {
-      return details::enum_in_array_name_size<Enum{}>();
-    }
-    else {
-#if __GNUC__ == 10
-      return details::gcc10_workaround<static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
-#else
-      constexpr auto  s      = details::enum_in_array_name_size<Enum{}>();
-      constexpr auto& tyname = raw_type_name<Enum>;
-      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
-        return s + tyname.substr(pos).size();
-      }
-      else {
-        return s + tyname.size();
-      }
-#endif
+    return details::length_of_enum_in_template_array_if_casting_impl<Enum>(std::integral_constant<bool, is_scoped_enum<Enum>>{});
+  }
+
+  constexpr const char* find_gcc_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == 's' && s[i + 2] == ' ' && s[i + 3] == '=' && s[i + 4] == ' ' && s[i + 5] == '{')
+        return s + i + SZC("Vs = {");
     }
   }
 
-  template<auto... Vs>
+  template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
-    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() [with auto ...Vs = {");
+    return details::find_gcc_values_pack(__PRETTY_FUNCTION__);
   }
 
 
@@ -150,7 +163,7 @@ namespace details {
         // although gcc implementation of std::char_traits::find is using a for loop internally
         // copying the code of the function makes it way slower to compile, this was surprising.
         const auto commapos = static_cast<std::size_t>(std::char_traits<char>::find(str, UINT8_MAX, ',') - str);
-        if constexpr (IsBitFlag)
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
@@ -164,52 +177,64 @@ namespace details {
   }
 
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
-  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
   {
-
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      using Under              = std::underlying_type_t<E>;
-      using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, Under>, unsigned char, Under>>;
-
-
-      constexpr auto str = [](const auto dependant) {
 #if __GNUC__ <= 10
-      // GCC 10 does not have it
   #define CAST(type, value) static_cast<type>(value)
 #else
-      // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
-        // dummy 0
-        if constexpr (sizeof(dependant) && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<E{}, CAST(E, static_cast<Under>(Underlying{1} << Is))..., 0>();
-        else
-          return details::var_name<CAST(E, static_cast<Under>(static_cast<decltype(Min)>(Is) + Min))..., 0>();
+    return details::var_name<E, E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., E{}>();
 #undef CAST
-      }(0);
+  }
 
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
-      constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+#if __GNUC__ <= 10
+  #define CAST(type, value) static_cast<type>(value)
+#else
+  #define CAST(type, value) __builtin_bit_cast(type, value)
+#endif
+    return details::var_name<E, CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., E{}>();
+#undef CAST
+  }
 
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-        /*least_length_when_casting=*/SZC("(") + length_of_enum_in_template_array_casting + SZC(")0"),
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<std::underlying_type_t<E>>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-      return ret;
-    }();
-    using Strings = std::array<char, elements_local.total_string_length>;
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    using Under              = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, Under>::value, unsigned char, Under>>;
+
+    constexpr auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+    constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
+
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+      /*least_length_when_casting=*/SZC("(") + length_of_enum_in_template_array_casting + SZC(")0"),
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<std::underlying_type_t<E>>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
@@ -222,7 +247,7 @@ namespace details {
     return data;
   }
 
-  template<typename E, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
   constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
   {
     constexpr auto ArraySize = sizeof...(Is);
@@ -235,7 +260,7 @@ namespace details {
     // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
-    constexpr auto str = details::var_name<CAST(E, static_cast<Under>(static_cast<decltype(Min)>(Is) + Min))..., 0>();
+    constexpr auto str = details::var_name<E, CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., E{}>();
 #undef CAST
 
     constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -34,7 +34,7 @@ namespace details {
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
                           SZC(__PRETTY_FUNCTION__) -
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
-    s.remove_prefix(s.find(';') + SZC(" E Enum = "));
+    s.remove_prefix(s.find(';') + SZC("; E Enum = "));
     // if scoped
     if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -122,14 +122,11 @@ namespace details {
 
   constexpr const char* find_char(const char* s, const std::size_t count, const char c) noexcept
   {
-#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
-    return std::char_traits<char>::find(s, count, c);
-#else
-    for (std::size_t i = 0; i < count; ++i)
-      if (s[i] == c)
+    for (std::size_t i = 0; i < count; ++i) {
+      if (s[i] == c || s[i] == '\0')
         return s + i;
+    }
     return nullptr;
-#endif
   }
 
   template<typename E, E... Vs>
@@ -142,8 +139,12 @@ namespace details {
   constexpr bool is_out_of_range_parse(const char* str, const std::size_t least_length_when_casting, const std::size_t array_size)
   {
     for (std::size_t index = 0; index < array_size; ++index) {
-      if (*str == '(')
-        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+      if (*str == '(') {
+        const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return false;
+        str = comma + SZC(", ");
+      }
       else
         return true;
     }
@@ -168,11 +169,17 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return;
+        str = comma + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(details::find_char(str, UINT8_MAX, ',') - str);
+        const auto comma = details::find_char(str, UINT8_MAX, ',');
+        if (comma == nullptr)
+          return;
+        const auto commapos = static_cast<std::size_t>(comma - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -181,7 +188,9 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
-        str += commapos + SZC(", ");
+        if (*comma == '\0')
+          return;
+        str = comma + SZC(", ");
       }
     }
   }

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -34,7 +34,10 @@ namespace details {
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
                           SZC(__PRETTY_FUNCTION__) -
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
-    s.remove_prefix(s.find(';') + SZC("; E Enum = "));
+    std::size_t enum_pos = 0;
+    while (s[enum_pos] != ';')
+      ++enum_pos;
+    s.remove_prefix(enum_pos + SZC("; E Enum = "));
     // if scoped
     if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -120,6 +120,18 @@ namespace details {
     }
   }
 
+  constexpr const char* find_char(const char* s, const std::size_t count, const char c) noexcept
+  {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return std::char_traits<char>::find(s, count, c);
+#else
+    for (std::size_t i = 0; i < count; ++i)
+      if (s[i] == c)
+        return s + i;
+    return nullptr;
+#endif
+  }
+
   template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
@@ -131,7 +143,7 @@ namespace details {
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(')
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
       else
         return true;
     }
@@ -156,13 +168,11 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        // although gcc implementation of std::char_traits::find is using a for loop internally
-        // copying the code of the function makes it way slower to compile, this was surprising.
-        const auto commapos = static_cast<std::size_t>(std::char_traits<char>::find(str, UINT8_MAX, ',') - str);
+        const auto commapos = static_cast<std::size_t>(details::find_char(str, UINT8_MAX, ',') - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else

--- a/enchantum/include/enchantum/details/enchantum_gcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_gcc.hpp
@@ -25,6 +25,32 @@ namespace details {
 
 
   // this is needed since gcc transforms "{anonymous}" into "<unnamed>" for values
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto Enum>
+  constexpr auto enum_in_array_name_size() noexcept
+  {
+    // constexpr auto f() [with auto _ = (
+    //constexpr auto f() [with auto _ = (Scoped)0]
+    auto s  = string_view(__PRETTY_FUNCTION__ +
+                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = "),
+                         SZC(__PRETTY_FUNCTION__) -
+                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = ]"));
+    using E = decltype(Enum);
+    // if scoped
+    if constexpr (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
+      return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;
+    }
+    else {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("("));
+        s.remove_suffix(SZC(")0"));
+      }
+      if (const auto pos = s.rfind(':'); pos != s.npos)
+        return pos - 1;
+      return std::size_t{0};
+    }
+  }
+#else
   template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
@@ -53,8 +79,42 @@ namespace details {
       return std::size_t{0};
     }
   }
+#endif
 
 #if __GNUC__ == 10
+  #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto V>
+  constexpr auto gcc10_workaround() noexcept
+  {
+    using E               = decltype(V);
+    using T               = std::underlying_type_t<E>;
+    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with auto V = ");
+    constexpr auto begin  = __PRETTY_FUNCTION__ + prefix;
+    if constexpr (begin[0] == '(') {
+      std::size_t i   = SZC(__PRETTY_FUNCTION__) - prefix - SZC("(");
+      const char* end = __PRETTY_FUNCTION__ + SZC(__PRETTY_FUNCTION__) - 1;
+      while (*end != ')') {
+        --end;
+        --i;
+      }
+      --i;
+      return i;
+    }
+    else if constexpr (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
+      constexpr auto  s      = details::enum_in_array_name_size<E{}>();
+      constexpr auto& tyname = raw_type_name<E>;
+      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+        return s + tyname.substr(pos).size();
+      }
+      else {
+        return s + tyname.size();
+      }
+    }
+    else {
+      return details::gcc10_workaround<static_cast<E>(static_cast<T>(V) + 1)>();
+    }
+  }
+  #else
   template<typename E, E V>
   constexpr auto gcc10_workaround() noexcept
   {
@@ -86,8 +146,32 @@ namespace details {
       return details::gcc10_workaround<E, static_cast<E>(static_cast<T>(V) + 1)>();
     }
   }
+  #endif
 #endif
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting() noexcept
+  {
+    if constexpr (is_scoped_enum<Enum>) {
+      return details::enum_in_array_name_size<Enum{}>();
+    }
+    else {
+#if __GNUC__ == 10
+      return details::gcc10_workaround<static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
+#else
+      constexpr auto  s      = details::enum_in_array_name_size<Enum{}>();
+      constexpr auto& tyname = raw_type_name<Enum>;
+      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+        return s + tyname.substr(pos).size();
+      }
+      else {
+        return s + tyname.size();
+      }
+#endif
+    }
+  }
+#else
   template<typename Enum>
   constexpr auto length_of_enum_in_template_array_if_casting_impl(std::true_type) noexcept
   {
@@ -114,7 +198,9 @@ namespace details {
   {
     return details::length_of_enum_in_template_array_if_casting_impl<Enum>(std::integral_constant<bool, is_scoped_enum<Enum>>{});
   }
+#endif
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_gcc_values_pack(const char* s) noexcept
   {
     for (std::size_t i = 0; true; ++i) {
@@ -137,16 +223,30 @@ namespace details {
   {
     return details::find_gcc_values_pack(__PRETTY_FUNCTION__);
   }
+#else
+  template<auto... Vs>
+  constexpr auto var_name() noexcept
+  {
+    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() [with auto ...Vs = {");
+  }
+#endif
 
 
   constexpr bool is_out_of_range_parse(const char* str, const std::size_t least_length_when_casting, const std::size_t array_size)
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return false;
+        str = comma + SZC(", ");
+#else
         const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
         if (comma == nullptr || *comma == '\0')
           return false;
         str = comma + SZC(", ");
+#endif
       }
       else
         return true;
@@ -172,17 +272,31 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return;
+        str = comma + SZC(", ");
+#else
         const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
         if (comma == nullptr || *comma == '\0')
           return;
         str = comma + SZC(", ");
+#endif
       }
       else {
         str += least_length_when_value;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str, UINT8_MAX, ',');
+        if (comma == nullptr)
+          return;
+        const auto commapos = static_cast<std::size_t>(comma - str);
+#else
         const auto comma = details::find_char(str, UINT8_MAX, ',');
         if (comma == nullptr)
           return;
         const auto commapos = static_cast<std::size_t>(comma - str);
+#endif
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -191,9 +305,13 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        str += commapos + SZC(", ");
+#else
         if (*comma == '\0')
           return;
         str = comma + SZC(", ");
+#endif
       }
     }
   }
@@ -207,7 +325,11 @@ namespace details {
 #else
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., 0>();
+#else
     return details::var_name<E, E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., E{}>();
+#endif
 #undef CAST
   }
 
@@ -219,7 +341,11 @@ namespace details {
 #else
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., 0>();
+#else
     return details::var_name<E, CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., E{}>();
+#endif
 #undef CAST
   }
 
@@ -232,7 +358,11 @@ namespace details {
 
     constexpr auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
+#else
     constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+#endif
     constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
 
     ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
@@ -282,7 +412,11 @@ namespace details {
     // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto str = details::var_name<CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., 0>();
+#else
     constexpr auto str = details::var_name<E, CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., E{}>();
+#endif
 #undef CAST
 
     constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();

--- a/enchantum/include/enchantum/details/enchantum_msvc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_msvc.hpp
@@ -38,6 +38,33 @@ namespace details {
     return s.npos;
   }
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto Enum>
+  constexpr auto enum_in_array_name_size() noexcept
+  {
+    auto s = string_view{__FUNCSIG__ + SZC("auto __cdecl enchantum::details::enum_in_array_name_size<"),
+                         SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::enum_in_array_name_size<>(void) noexcept")};
+    using E = decltype(Enum);
+
+    if constexpr (is_scoped_enum<E>) {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("(enum "));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
+        return s.size();
+      }
+      return s.substr(0, s.rfind(':') - 1).size();
+    }
+    else {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("(enum "));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
+      }
+      if (const auto pos = s.rfind(':'); pos != s.npos)
+        return pos - 1;
+      return std::size_t(0);
+    }
+  }
+#else
   template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
@@ -64,7 +91,16 @@ namespace details {
       return std::size_t(0);
     }
   }
+#endif
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto... Vs>
+  constexpr auto __cdecl var_name() noexcept
+  {
+    //auto __cdecl f<class std::array<enum `anonymous namespace'::UnscopedAnon,32>{enum `anonymous-namespace'::UnscopedAnon
+    return __FUNCSIG__ + SZC("auto __cdecl enchantum::details::var_name<");
+  }
+#else
   template<typename E, E... Vs>
   constexpr auto __cdecl var_name() noexcept
   {
@@ -73,6 +109,7 @@ namespace details {
     constexpr auto        pos = details::find_type_value_separator(sig, SZC("auto __cdecl enchantum::details::var_name<"));
     return __FUNCSIG__ + pos + SZC(",");
   }
+#endif
   template<typename IntType>
   constexpr bool is_out_of_range_parse(const char*       str,
                                        const bool        skip_work_if_neg,
@@ -204,13 +241,21 @@ namespace details {
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::true_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<E{}, static_cast<E>(Underlying(1) << Is)..., 0>();
+#else
     return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+#endif
   }
 
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::false_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
   }
 
   template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
@@ -223,7 +268,11 @@ namespace details {
 
     constexpr auto str               = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
     constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
+#else
     constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+#endif
 
     ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
     details::parse_string<is_bitflag<E>>(
@@ -287,7 +336,11 @@ namespace details {
 #else
     constexpr auto skip_work_if_neg = false;
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    const auto str           = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     const auto str           = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
     const auto type_name_len = details::raw_type_name_func<E>().size() - 1;
 
     return details::is_out_of_range_parse(

--- a/enchantum/include/enchantum/details/enchantum_msvc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_msvc.hpp
@@ -3,7 +3,6 @@
 #include "../type_name.hpp"
 #include "shared.hpp"
 #include "string_view.hpp"
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -25,13 +24,28 @@ namespace enchantum {
 #define SZC(x) (sizeof(x) - 1)
 namespace details {
 
-  template<auto Enum>
+  constexpr std::size_t find_type_value_separator(const string_view s, const std::size_t start) noexcept
+  {
+    std::size_t depth = 0;
+    for (std::size_t i = start; i < s.size(); ++i) {
+      if (s[i] == '<')
+        ++depth;
+      else if (s[i] == '>')
+        --depth;
+      else if (s[i] == ',' && depth == 0)
+        return i;
+    }
+    return s.npos;
+  }
+
+  template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
     auto s = string_view{__FUNCSIG__ + SZC("auto __cdecl enchantum::details::enum_in_array_name_size<"),
                          SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::enum_in_array_name_size<>(void) noexcept")};
+    s.remove_prefix(details::find_type_value_separator(s, 0) + 1);
 
-    if constexpr (is_scoped_enum<decltype(Enum)>) {
+    if (is_scoped_enum<E>) {
       if (s[0] == '(') {
         s.remove_prefix(SZC("(enum "));
         s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
@@ -44,17 +58,20 @@ namespace details {
         s.remove_prefix(SZC("(enum "));
         s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
       }
-      if (const auto pos = s.rfind(':'); pos != s.npos)
+      const auto pos = s.rfind(':');
+      if (pos != s.npos)
         return pos - 1;
       return std::size_t(0);
     }
   }
 
-  template<auto... Vs>
+  template<typename E, E... Vs>
   constexpr auto __cdecl var_name() noexcept
   {
     //auto __cdecl f<class std::array<enum `anonymous namespace'::UnscopedAnon,32>{enum `anonymous-namespace'::UnscopedAnon
-    return __FUNCSIG__ + SZC("auto __cdecl enchantum::details::var_name<");
+    constexpr string_view sig{__FUNCSIG__, SZC(__FUNCSIG__)};
+    constexpr auto        pos = details::find_type_value_separator(sig, SZC("auto __cdecl enchantum::details::var_name<"));
+    return __FUNCSIG__ + pos + SZC(",");
   }
   template<typename IntType>
   constexpr bool is_out_of_range_parse(const char*       str,
@@ -89,6 +106,33 @@ namespace details {
     return false;
   }
 
+  template<typename IntType>
+  constexpr IntType parse_string_value(const std::size_t index, const IntType, std::true_type) noexcept
+  {
+    return index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
+  }
+
+  template<typename IntType>
+  constexpr IntType parse_string_value(const std::size_t index, const IntType min, std::false_type) noexcept
+  {
+    return static_cast<IntType>(min + static_cast<IntType>(index));
+  }
+
+  template<typename IntType, std::size_t SkipIfNegative>
+  constexpr const char* skip_casted_value_string(
+    const char* str, const std::size_t least_length_when_casting, const IntType min, const std::size_t index, std::integral_constant<std::size_t, SkipIfNegative>) noexcept
+  {
+    const auto i = min + static_cast<IntType>(index);
+    return str + least_length_when_casting + ((i < 0) * SkipIfNegative);
+  }
+
+  template<typename IntType>
+  constexpr const char* skip_casted_value_string(
+    const char* str, const std::size_t least_length_when_casting, const IntType, const std::size_t, std::integral_constant<std::size_t, 0>) noexcept
+  {
+    return str + least_length_when_casting;
+  }
+
   template<bool IsBitFlag, typename IntType>
   constexpr void parse_string(
     const char*         str,
@@ -105,13 +149,13 @@ namespace details {
   {
     // clang-format off
 #if ENCHANTUM_ENABLE_MSVC_SPEEDUP
-    constexpr auto skip_work_if_neg = IsBitFlag || std::is_unsigned_v<IntType> || sizeof(IntType) <= 2 ? 0 : 
+    constexpr auto skip_work_if_neg = IsBitFlag || std::is_unsigned<IntType>::value || sizeof(IntType) <= 2 ? 0 :
 // MSVC 19.31 and below don't cast int/unsigned int into `unsigned long long` (std::uint64_t)
 // While higher versions do cast them
 #if _MSC_VER <= 1931
         sizeof(IntType) == 4
 #else
-        std::is_same_v<IntType,char32_t> 
+        std::is_same<IntType,char32_t>::value
 #endif
         ? sizeof(char32_t)*2-1 : sizeof(std::uint64_t)*2-1 - (sizeof(IntType)==8); // subtract 1 more from uint64_t since I am adding it in skip_if_cast_count
 #endif
@@ -126,13 +170,11 @@ namespace details {
       if (*str == '(') {
 #endif
 #if ENCHANTUM_ENABLE_MSVC_SPEEDUP
-        if constexpr (skip_work_if_neg != 0) {
-          const auto i = min + static_cast<IntType>(index);
-          str += least_length_when_casting + ((i < 0) * skip_work_if_neg);
-        }
-        else {
-          str += least_length_when_casting;
-        }
+        str = details::skip_casted_value_string(str,
+                                                least_length_when_casting,
+                                                min,
+                                                index,
+                                                std::integral_constant<std::size_t, skip_work_if_neg>{});
 #else
         str += least_length_when_casting;
 #endif
@@ -146,10 +188,7 @@ namespace details {
         // copying the code of the function makes it way slower to compile, this was surprising.
 
 
-        if constexpr (IsBitFlag)
-          values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
-        else
-          values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
+        values[valid_count] = details::parse_string_value(index, min, std::integral_constant<bool, IsBitFlag>{});
 
         std::size_t i = 0;
         while (str[i] != ',')
@@ -162,49 +201,57 @@ namespace details {
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
+  {
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    using Under              = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, Under>::value, unsigned char, Under>>;
+
+
+    constexpr auto str               = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+    constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+#if _MSC_VER <= 1924
+      /*least_length_when_casting=*/SZC("0x0"),
+#else
+      /*least_length_when_casting=*/SZC("(enum ") + type_name_len + SZC(")0x0") + (sizeof(E) == 8),
+#endif
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<std::underlying_type_t<E>>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
   constexpr auto reflect(std::index_sequence<Is...>) noexcept
   {
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      using MinT               = decltype(Min);
-      using Under              = std::underlying_type_t<E>;
-      using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, Under>, unsigned char, Under>>;
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
 
-
-      constexpr auto str = [](const auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        else
-          return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-      }(0);
-      constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
-
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-#if _MSC_VER <= 1924
-        /*least_length_when_casting=*/SZC("0x0"),
-#else
-        /*least_length_when_casting=*/SZC("(enum ") + type_name_len + SZC(")0x0") + (sizeof(E) == 8),
-#endif
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<std::underlying_type_t<E>>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-      return ret;
-    }();
-
-    using Strings = std::array<char, elements_local.total_string_length>;
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
@@ -219,21 +266,20 @@ namespace details {
   }
 
 
-  template<typename E, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
   constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
   {
     constexpr auto ArraySize = sizeof...(Is);
-    using MinT               = decltype(Min);
     using Under              = std::underlying_type_t<E>;
 
 #if ENCHANTUM_ENABLE_MSVC_SPEEDUP
-    constexpr auto skip_work_if_neg = std::is_unsigned_v<Under> || sizeof(Under) <= 2 ? 0 :
+    constexpr auto skip_work_if_neg = std::is_unsigned<Under>::value || sizeof(Under) <= 2 ? 0 :
   // MSVC 19.31 and below don't cast int/unsigned int into `unsigned long long` (std::uint64_t)
   // While higher versions do cast them
   #if _MSC_VER <= 1931
       sizeof(Under) == 4
   #else
-      std::is_same_v<Under, char32_t>
+      std::is_same<Under, char32_t>::value
   #endif
       ? sizeof(char32_t) * 2 - 1
       : sizeof(std::uint64_t) * 2 - 1 -
@@ -241,7 +287,7 @@ namespace details {
 #else
     constexpr auto skip_work_if_neg = false;
 #endif
-    const auto str           = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+    const auto str           = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
     const auto type_name_len = details::raw_type_name_func<E>().size() - 1;
 
     return details::is_out_of_range_parse(

--- a/enchantum/include/enchantum/details/enchantum_nvcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_nvcc.hpp
@@ -1,7 +1,6 @@
 #include "../common.hpp"
 #include "../type_name.hpp"
 #include "shared.hpp"
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -10,28 +9,38 @@
 namespace enchantum {
 
 namespace details {
+#define SZC(x) (sizeof(x) - 1)
+
   constexpr std::size_t find_semicolon(const char* s)
   {
     for (std::size_t i = 0; true; ++i)
       if (s[i] == ';')
         return i;
   }
+
+  constexpr const char* find_nvcc_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == ' ' && s[i + 2] == '=' && s[i + 3] == ' ' && s[i + 4] == '{')
+        return s + i + SZC("V = {");
+    }
+  }
+
   constexpr std::size_t enum_in_array_name_size(const string_view raw_type_name, const bool is_scoped_enum) noexcept
   {
     if (is_scoped_enum)
       return raw_type_name.size();
 
-    if (const auto pos = raw_type_name.rfind(':'); pos != string_view::npos)
+    const auto pos = raw_type_name.rfind(':');
+    if (pos != string_view::npos)
       return pos - 1;
     return 0;
   }
 
-#define SZC(x) (sizeof(x) - 1)
-
-  template<auto... V>
+  template<typename E, E... V>
   constexpr auto var_name() noexcept
   {
-    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() noexcept [with _ *V = (_ *)0; ");
+    return details::find_nvcc_values_pack(__PRETTY_FUNCTION__);
   }
 
   template<bool IsBitFlag, typename IntType>
@@ -50,79 +59,81 @@ namespace details {
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       // check if cast (starts with '(')
-      str += SZC("_ *V = ");
       if (str[0] == '(') {
         str += least_length_when_casting;
-        while (*str++ != ';')
+        while (*str++ != ',')
           /*intentionally empty*/;
         str += SZC(" ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = details::find_semicolon(str);
-        if constexpr (IsBitFlag)
+        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
         string_lengths[valid_count++] = static_cast<std::uint8_t>(commapos);
         __builtin_memcpy(strings + total_string_length, str, commapos);
         total_string_length += commapos + null_terminated;
-        str += commapos + SZC("; ");
+        str += commapos + SZC(", ");
       }
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
-  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
   {
-    using MinT = decltype(Min);
-    using T    = std::underlying_type_t<E>;
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
 
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
 #pragma diag_suppress implicit_return_from_non_void_function
-      const auto str = [](auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // forces NVCC to shorten the string types
-        struct _ {};
-        // using a pointer since C++17 only allows pointers to class types not the class types themselves
-        constexpr _* A{};
-        using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, T>, unsigned char, T>>;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<A, static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        else
-          return details::var_name<A, static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-      }(0);
+    const auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
 #pragma diag_default implicit_return_from_non_void_function
 
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size(raw_type_name<E>, is_scoped_enum<E>);
-      // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size(raw_type_name<E>, is_scoped_enum<E>);
+    // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
 
-      // ((anonymous namespace)::A)0
-      // (anonymous namespace)::a
-      // this is needed to determine whether the above are cast expression if 2 braces are
-      // next to eachother then it is a cast but only for anonymoused namespaced enums
+    // ((anonymous namespace)::A)0
+    // (anonymous namespace)::a
+    // this is needed to determine whether the above are cast expression if 2 braces are
+    // next to eachother then it is a cast but only for anonymoused namespaced enums
 
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-        /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<T>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+      /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<T>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
 
-      return ret;
-    }();
+    return ret;
+  }
 
-    using Strings = std::array<char, elements_local.total_string_length>;
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;

--- a/enchantum/include/enchantum/details/enchantum_nvcc.hpp
+++ b/enchantum/include/enchantum/details/enchantum_nvcc.hpp
@@ -11,10 +11,10 @@ namespace enchantum {
 namespace details {
 #define SZC(x) (sizeof(x) - 1)
 
-  constexpr std::size_t find_semicolon(const char* s)
+  constexpr std::size_t find_comma(const char* s)
   {
     for (std::size_t i = 0; true; ++i)
-      if (s[i] == ';')
+      if (s[i] == ',')
         return i;
   }
 
@@ -67,7 +67,7 @@ namespace details {
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        const auto commapos = details::find_comma(str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else

--- a/enchantum/include/enchantum/details/enchantum_resharper_cpp.hpp
+++ b/enchantum/include/enchantum/details/enchantum_resharper_cpp.hpp
@@ -3,7 +3,6 @@
 #include "../common.hpp"
 #include "shared.hpp"
 #include "string_view.hpp"
-#include <array>
 #include <cstdint>
 #include <initializer_list>
 #include <type_traits>
@@ -21,65 +20,69 @@ namespace details {
   template<std::size_t Count, typename Value, std::size_t... Is>
   constexpr auto rscpp_make_defaulted_array_of(const Value value, std::index_sequence<Is...>)
   {
-    return std::array<Value, Count>{(Is, void(), value)...};
+    return details::array<Value, Count>{(Is, void(), value)...};
   }
 
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
-  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
   {
-    using MinT = decltype(Min);
     using T    = std::underlying_type_t<E>;
-    using U    = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, T>, unsigned char, T>>;
+    using U    = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
     constexpr bool        IsBitFlag    = is_bitflag<E>;
     constexpr std::size_t max_elements = sizeof...(Is) + IsBitFlag;
 
-    constexpr auto elements_local = [] {
-      const char* names[max_elements]{};
-      T           values[max_elements]{};
-      std::size_t count = 0;
+    const char* names[max_elements]{};
+    T           values[max_elements]{};
+    std::size_t count = 0;
 
-      if constexpr (IsBitFlag) {
-        if (const auto* name = __rscpp_enumerator_name(E(0))) {
+    if (IsBitFlag) {
+      const auto* zero_name = __rscpp_enumerator_name(E(0));
+      if (zero_name) {
+        names[count]    = zero_name;
+        values[count++] = 0;
+      }
+
+      for (std::size_t i : {Is...}) {
+        const auto val  = T(U(1) << i);
+        const auto name = __rscpp_enumerator_name(E(val));
+        if (name) {
           names[count]    = name;
-          values[count++] = 0;
-        }
-
-        for (std::size_t i : {Is...}) {
-          const auto val  = T(U(1) << i);
-          const auto name = __rscpp_enumerator_name(E(val));
-          if (name) {
-            names[count]    = name;
-            values[count++] = val;
-          }
+          values[count++] = val;
         }
       }
-      else {
-        for (std::size_t i = 0; i < max_elements; ++i) {
-          const auto val  = T(MinT(i) + Min);
-          const auto name = __rscpp_enumerator_name(E(val));
-          if (name) {
-            names[count]    = name;
-            values[count++] = val;
-          }
+    }
+    else {
+      for (std::size_t i = 0; i < max_elements; ++i) {
+        const auto val  = T(MinT(i) + Min);
+        const auto name = __rscpp_enumerator_name(E(val));
+        if (name) {
+          names[count]    = name;
+          values[count++] = val;
         }
       }
+    }
 
-      auto ret = ReflectStringReturnValue<T, max_elements>{};
-      for (std::size_t i = 0; i < count; ++i) {
-        const auto        str = names[i] + prefix_length_or_zero<E>;
-        const std::size_t len = __builtin_strlen(str);
-        ret.values[i]         = values[i];
-        ret.string_lengths[i] = len;
-        for (std::size_t j = 0; j < len; ++j)
-          ret.strings[ret.total_string_length + j] = str[j];
-        ret.total_string_length += len + (NullTerminated ? 1 : 0);
-      }
-      ret.valid_count = count;
-      return ret;
-    }();
+    auto ret = ReflectStringReturnValue<T, max_elements>{};
+    for (std::size_t i = 0; i < count; ++i) {
+      const auto        str = names[i] + prefix_length_or_zero<E>;
+      const std::size_t len = __builtin_strlen(str);
+      ret.values[i]         = values[i];
+      ret.string_lengths[i] = len;
+      for (std::size_t j = 0; j < len; ++j)
+        ret.strings[ret.total_string_length + j] = str[j];
+      ret.total_string_length += len + (NullTerminated ? 1 : 0);
+    }
+    ret.valid_count = count;
+    return ret;
+  }
 
-    using Strings = std::array<char, elements_local.total_string_length>;
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;

--- a/enchantum/include/enchantum/details/format_util.hpp
+++ b/enchantum/include/enchantum/details/format_util.hpp
@@ -6,24 +6,40 @@
 
 namespace enchantum {
 namespace details {
+  template<typename String>
+  std::string string_to_std_string(const String& name, std::true_type)
+  {
+    return name;
+  }
+
+  template<typename String>
+  std::string string_to_std_string(const String& name, std::false_type)
+  {
+    return std::string(name.data(), name.size());
+  }
+
+  template<typename E>
+  std::string format_impl(E e, std::true_type) noexcept
+  {
+    const auto name = enchantum::to_string_bitflag(e);
+    if (!name.empty())
+      return details::string_to_std_string(name, std::integral_constant<bool, std::is_same<std::string, string>::value>{});
+    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+  }
+
+  template<typename E>
+  std::string format_impl(E e, std::false_type) noexcept
+  {
+    const auto name = enchantum::to_string(e);
+    if (!name.empty())
+      return std::string(name.data(), name.size());
+    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+  }
+
   template<typename E>
   std::string format(E e) noexcept
   {
-    if constexpr (is_bitflag<E>) {
-      if (const auto name = enchantum::to_string_bitflag(e); !name.empty()) {
-        if constexpr (std::is_same_v<std::string, string>) {
-          return name;
-        }
-        else {
-          return std::string(name.data(), name.size());
-        }
-      }
-    }
-    else {
-      if (const auto name = enchantum::to_string(e); !name.empty())
-        return std::string(name.data(), name.size());
-    }
-    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+    return format_impl(e, std::integral_constant<bool, is_bitflag<E>>{});
   }
 } // namespace details
 } // namespace enchantum

--- a/enchantum/include/enchantum/details/optional.hpp
+++ b/enchantum/include/enchantum/details/optional.hpp
@@ -1,13 +1,18 @@
 #pragma once
 
+#include "compat.hpp"
+
 #ifdef ENCHANTUM_CONFIG_FILE
   #include ENCHANTUM_CONFIG_FILE
+#endif
+
+#if !defined(ENCHANTUM_ALIAS_OPTIONAL) && ENCHANTUM_DETAILS_CXX_STD < 201703L
+  #error "C++14 users must define ENCHANTUM_ALIAS_OPTIONAL to an optional-compatible template alias."
 #endif
 
 #ifndef ENCHANTUM_ALIAS_OPTIONAL
   #include <optional>
 #endif
-
 
 namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_OPTIONAL

--- a/enchantum/include/enchantum/details/shared.hpp
+++ b/enchantum/include/enchantum/details/shared.hpp
@@ -11,10 +11,10 @@ namespace details {
 
 
   template<typename E, typename = void>
-  inline constexpr std::size_t prefix_length_or_zero = 0;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr std::size_t prefix_length_or_zero = 0;
 
   template<typename E>
-  inline constexpr auto prefix_length_or_zero<E, decltype((void)enum_traits<E>::prefix_length)> = std::size_t{
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto prefix_length_or_zero<E, decltype((void)enum_traits<E>::prefix_length)> = std::size_t{
     enum_traits<E>::prefix_length};
 
   template<typename Underlying, std::size_t ArraySize>

--- a/enchantum/include/enchantum/details/string_view.hpp
+++ b/enchantum/include/enchantum/details/string_view.hpp
@@ -18,7 +18,7 @@ namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_STRING_VIEW
 ENCHANTUM_ALIAS_STRING_VIEW;
 #else
-using ::std ::string_view;
+using ::std::string_view;
 #endif
 
 } // namespace enchantum

--- a/enchantum/include/enchantum/details/string_view.hpp
+++ b/enchantum/include/enchantum/details/string_view.hpp
@@ -1,20 +1,24 @@
 #pragma once
 
+#include "compat.hpp"
 
 #ifdef ENCHANTUM_CONFIG_FILE
   #include ENCHANTUM_CONFIG_FILE
+#endif
+
+#if !defined(ENCHANTUM_ALIAS_STRING_VIEW) && ENCHANTUM_DETAILS_CXX_STD < 201703L
+  #error "C++14 users must define ENCHANTUM_ALIAS_STRING_VIEW to a string_view-compatible alias."
 #endif
 
 #ifndef ENCHANTUM_ALIAS_STRING_VIEW
   #include <string_view>
 #endif
 
-
 namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_STRING_VIEW
 ENCHANTUM_ALIAS_STRING_VIEW;
 #else
-using ::std::string_view;
+using ::std ::string_view;
 #endif
 
 } // namespace enchantum

--- a/enchantum/include/enchantum/enchantum.hpp
+++ b/enchantum/include/enchantum/enchantum.hpp
@@ -144,8 +144,10 @@ namespace details {
       return optional<std::size_t>(0); // assumes 0 is the index of value `0`
 
     using U = typename std::make_unsigned<T>::type;
-    return optional<std::size_t>(std::size_t(has_zero) + details::countr_zero(static_cast<U>(e)) -
-                                details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+    const auto value_offset = static_cast<std::size_t>(details::countr_zero(static_cast<U>(e)));
+    const auto base_offset =
+      static_cast<std::size_t>(details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+    return optional<std::size_t>(std::size_t(has_zero) + value_offset - base_offset);
   }
 
   template<typename E>

--- a/enchantum/include/enchantum/enchantum.hpp
+++ b/enchantum/include/enchantum/enchantum.hpp
@@ -163,19 +163,19 @@ namespace details {
 
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const std::underlying_type_t<E> value) noexcept
 {
   return details::contains_value<E>(value);
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const E value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const E value) noexcept
 {
   return enchantum::contains<E>(static_cast<std::underlying_type_t<E>>(value));
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const string_view name) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name) noexcept
 {
   constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
   const auto size = name.size();
@@ -192,7 +192,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
 {
   for (std::size_t i = 0; i < count<E>; ++i) {
     const auto s = names_generator<E>[i];
@@ -206,7 +206,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
 namespace details {
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   struct index_to_enum_functor {
-    [[nodiscard]] constexpr optional<E> operator()(const std::size_t index) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const std::size_t index) const noexcept
     {
       if (index < count<E>)
         return optional<E>(values_generator<E>[index]);
@@ -216,7 +216,7 @@ namespace details {
 
   struct enum_to_index_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr optional<std::size_t> operator()(const E e) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<std::size_t> operator()(const E e) const noexcept
     {
       return details::enum_to_index_impl<E>(e,
                                             std::integral_constant<bool, is_contiguous<E> && count<E> != 0>{},
@@ -227,14 +227,14 @@ namespace details {
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   struct cast_functor {
-    [[nodiscard]] constexpr optional<E> operator()(const std::underlying_type_t<E> value) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const std::underlying_type_t<E> value) const noexcept
     {
       if (!enchantum::contains<E>(value))
         return optional<E>();
       return optional<E>(static_cast<E>(value));
     }
 
-    [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name) const noexcept
     {
       constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
       const auto size = name.size();
@@ -250,7 +250,7 @@ namespace details {
     }
 
     template<typename BinaryPred>
-    [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_pred) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name, const BinaryPred binary_pred) const noexcept
     {
 
       for (std::size_t i = 0; i < count<E>; ++i) {
@@ -276,7 +276,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr details::cast_functor<E> cast{};
 namespace details {
   struct to_string_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr string_view operator()(const E value) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr string_view operator()(const E value) const noexcept
     {
       if (const auto i = enchantum::enum_to_index(value))
         return names_generator<E>[*i];

--- a/enchantum/include/enchantum/enchantum.hpp
+++ b/enchantum/include/enchantum/enchantum.hpp
@@ -106,8 +106,8 @@ namespace details {
   constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::false_type, std::false_type) noexcept
   {
     using T = typename std::underlying_type<E>::type;
-    for (const auto v : values_generator<E>)
-      if (static_cast<T>(v) == value)
+    for (std::size_t i = 0; i < count<E>; ++i)
+      if (static_cast<T>(values_generator<E>[i]) == value)
         return true;
     return false;
   }
@@ -180,9 +180,11 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   if (size < minmax.first || size > minmax.second)
     return false;
 
-  for (const auto s : names_generator<E>)
+  for (std::size_t i = 0; i < count<E>; ++i) {
+    const auto s = names_generator<E>[i];
     if (s == name)
       return true;
+  }
   return false;
 }
 
@@ -190,9 +192,11 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
 [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
 {
-  for (const auto s : names_generator<E>)
+  for (std::size_t i = 0; i < count<E>; ++i) {
+    const auto s = names_generator<E>[i];
     if (details::call_predicate(binary_pred, name, s))
       return true;
+  }
   return false;
 }
 

--- a/enchantum/include/enchantum/enchantum.hpp
+++ b/enchantum/include/enchantum/enchantum.hpp
@@ -23,25 +23,36 @@ namespace enchantum {
 
 namespace details {
   template<typename BinaryPredicate>
+  constexpr bool call_predicate_impl(const BinaryPredicate binary_pred, const string_view a, const string_view b, std::true_type)
+  {
+    const auto a_size = a.size();
+    if (a_size != b.size())
+      return false;
+    const auto a_data = a.data();
+    const auto b_data = b.data();
+
+    for (std::size_t i = 0; i < a_size; ++i)
+      if (!binary_pred(a_data[i], b_data[i]))
+        return false;
+    return true;
+  }
+
+  template<typename BinaryPredicate>
+  constexpr bool call_predicate_impl(const BinaryPredicate binary_pred, const string_view a, const string_view b, std::false_type)
+  {
+    static_assert(enchantum::details::is_invocable<const BinaryPredicate&, const string_view&, const string_view&>::value,
+                  "BinaryPredicate must be callable with either two chars or two string_views");
+    return binary_pred(a, b);
+  }
+
+  template<typename BinaryPredicate>
   constexpr bool call_predicate(const BinaryPredicate binary_pred, const string_view a, const string_view b)
   {
-    if constexpr (std::is_invocable_v<const BinaryPredicate&, const char&, const char&>) {
-      const auto a_size = a.size();
-      if (a_size != b.size())
-        return false;
-      const auto a_data = a.data();
-      const auto b_data = b.data();
-
-      for (std::size_t i = 0; i < a_size; ++i)
-        if (!binary_pred(a_data[i], b_data[i]))
-          return false;
-      return true;
-    }
-    else {
-      static_assert(std::is_invocable_v<const BinaryPredicate&, const string_view&, const string_view&>,
-                    "BinaryPredicate must be callable with atleast 2 char or 2 string_views");
-      return binary_pred(a, b);
-    }
+    return call_predicate_impl(binary_pred,
+                               a,
+                               b,
+                               enchantum::details::bool_constant<
+                                 enchantum::details::is_invocable<const BinaryPredicate&, const char&, const char&>::value>{});
   }
 
   constexpr std::pair<std::size_t, std::size_t> minmax_string_size(const string_view* begin, const string_view* const end)
@@ -60,32 +71,99 @@ namespace details {
 } // namespace details
 
 
-template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
-{
-  using T = std::underlying_type_t<E>;
-  if constexpr (count<E> != 0)
-    if (value < T(min<E>) || value > T(max<E>))
-      return false;
+namespace details {
+  template<typename E, bool Empty>
+  struct contains_bounds {
+    static constexpr bool outside(typename std::underlying_type<E>::type value) noexcept
+    {
+      using T = typename std::underlying_type<E>::type;
+      return value < T(min<E>) || value > T(max<E>);
+    }
+  };
 
-  if constexpr (is_contiguous_bitflag<E>) {
-    if constexpr (has_zero_flag<E>)
-      if (value == 0)
-        return true;
-    const auto u = static_cast<std::make_unsigned_t<T>>(value);
+  template<typename E>
+  struct contains_bounds<E, true> {
+    static constexpr bool outside(typename std::underlying_type<E>::type) noexcept { return false; }
+  };
 
-    // std::has_single_bit
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::true_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (has_zero_flag<E> ? value == 0 : false)
+      return true;
+    const auto u = static_cast<typename std::make_unsigned<T>::type>(value);
     return u != 0 && (u & (u - 1)) == 0;
   }
-  else if constexpr (is_contiguous<E>) {
+
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type, std::false_type, std::true_type) noexcept
+  {
     return true;
   }
-  else {
+
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::false_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
     for (const auto v : values_generator<E>)
       if (static_cast<T>(v) == value)
         return true;
     return false;
   }
+
+  template<typename E>
+  constexpr bool contains_value(typename std::underlying_type<E>::type value) noexcept
+  {
+    if (details::contains_bounds<E, count<E> == 0>::outside(value))
+      return false;
+
+    return details::contains_impl<E>(value,
+                                     std::integral_constant<bool, is_contiguous_bitflag<E>>{},
+                                     std::integral_constant<bool, is_contiguous<E>>{});
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::true_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (details::contains_value<E>(static_cast<T>(e)))
+      return optional<std::size_t>(std::size_t(T(e) - T(min<E>)));
+    return optional<std::size_t>();
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::false_type, std::true_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (!details::contains_value<E>(static_cast<T>(e)))
+      return optional<std::size_t>();
+
+    const bool has_zero = has_zero_flag<E>;
+    if (has_zero ? static_cast<T>(e) == 0 : false)
+      return optional<std::size_t>(0); // assumes 0 is the index of value `0`
+
+    using U = typename std::make_unsigned<T>::type;
+    return optional<std::size_t>(std::size_t(has_zero) + details::countr_zero(static_cast<U>(e)) -
+                                details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::false_type, std::false_type) noexcept
+  {
+    for (std::size_t i = 0; i < count<E>; ++i) {
+      if (values_generator<E>[i] == e)
+        return optional<std::size_t>(i);
+    }
+    return optional<std::size_t>();
+  }
+} // namespace details
+
+
+template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
+[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
+{
+  return details::contains_value<E>(value);
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
@@ -98,7 +176,8 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 [[nodiscard]] constexpr bool contains(const string_view name) noexcept
 {
   constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
-  if (const auto size = name.size(); size < minmax.first || size > minmax.second)
+  const auto size = name.size();
+  if (size < minmax.first || size > minmax.second)
     return false;
 
   for (const auto s : names_generator<E>)
@@ -133,32 +212,9 @@ namespace details {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
     [[nodiscard]] constexpr optional<std::size_t> operator()(const E e) const noexcept
     {
-      using T = std::underlying_type_t<E>;
-
-      if constexpr (is_contiguous<E> && count<E> != 0) {
-        if (enchantum::contains(e)) {
-          return optional<std::size_t>(std::size_t(T(e) - T(min<E>)));
-        }
-      }
-      else if constexpr (is_contiguous_bitflag<E>) {
-        if (enchantum::contains(e)) {
-          constexpr bool has_zero = has_zero_flag<E>;
-          if constexpr (has_zero)
-            if (static_cast<T>(e) == 0)
-              return optional<std::size_t>(0); // assumes 0 is the index of value `0`
-
-          using U = std::make_unsigned_t<T>;
-          return has_zero + details::countr_zero(static_cast<U>(e)) -
-            details::countr_zero(static_cast<U>(values_generator<E>[has_zero]));
-        }
-      }
-      else {
-        for (std::size_t i = 0; i < count<E>; ++i) {
-          if (values_generator<E>[i] == e)
-            return optional<std::size_t>(i);
-        }
-      }
-      return optional<std::size_t>();
+      return details::enum_to_index_impl<E>(e,
+                                            std::integral_constant<bool, is_contiguous<E> && count<E> != 0>{},
+                                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
     }
   };
 
@@ -175,7 +231,8 @@ namespace details {
     [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
     {
       constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
-      if (const auto size = name.size(); size < minmax.first || size > minmax.second)
+      const auto size = name.size();
+      if (size < minmax.first || size > minmax.second)
         return optional<E>(); // nullopt
 
       for (std::size_t i = 0; i < count<E>; ++i) {
@@ -202,12 +259,12 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::index_to_enum_functor<E> index_to_enum{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::index_to_enum_functor<E> index_to_enum{};
 
-inline constexpr details::enum_to_index_functor enum_to_index{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::enum_to_index_functor enum_to_index{};
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::cast_functor<E> cast{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::cast_functor<E> cast{};
 
 
 namespace details {
@@ -222,7 +279,7 @@ namespace details {
   };
 
 } // namespace details
-inline constexpr details::to_string_functor to_string{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::to_string_functor to_string{};
 
 
 } // namespace enchantum

--- a/enchantum/include/enchantum/entries.hpp
+++ b/enchantum/include/enchantum/entries.hpp
@@ -466,6 +466,40 @@ namespace details {
   };
 } // namespace details
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = [](const auto is_bitflag) {
+  if constexpr (is_bitflag.value) {
+    for (const auto v : values<E>)
+      if (static_cast<std::underlying_type_t<E>>(v) == 0)
+        return true;
+  }
+  return false;
+}(std::integral_constant<bool, is_bitflag<E>>{});
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = []() {
+  if constexpr (count<E> == 0)
+    return false;
+  else
+    return static_cast<std::size_t>(enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) + 1 == count<E>;
+}();
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = [](const auto is_bitflag) {
+  if constexpr (is_bitflag.value) {
+    constexpr auto& enums = entries<E>;
+    using T               = std::underlying_type_t<E>;
+    for (auto i = std::size_t{has_zero_flag<E>}; i < enums.size() - 1; ++i)
+      if (T(enums[i].first) << 1 != T(enums[i + 1].first))
+        return false;
+    return true;
+  }
+  else {
+    return false;
+  }
+}(std::integral_constant<bool, is_bitflag<E>>{});
+#else
 template<typename E>
 ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = details::has_zero_flag_impl<E, is_bitflag<E>>::value();
 
@@ -475,6 +509,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = details::is_contiguo
 
 template<typename E>
 ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = details::is_contiguous_bitflag_impl<E, is_bitflag<E>>::value();
+#endif
 
 #ifdef __cpp_concepts
 template<typename E>

--- a/enchantum/include/enchantum/entries.hpp
+++ b/enchantum/include/enchantum/entries.hpp
@@ -32,7 +32,7 @@ namespace enchantum {
 using ::std::to_underlying;
 #else
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr auto to_underlying(const E e) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr auto to_underlying(const E e) noexcept
 {
   return static_cast<std::underlying_type_t<E>>(e);
 }

--- a/enchantum/include/enchantum/entries.hpp
+++ b/enchantum/include/enchantum/entries.hpp
@@ -16,7 +16,6 @@
 #endif
 
 #include "common.hpp"
-#include <array>
 #include <climits>
 #include <type_traits>
 #include <utility>
@@ -69,37 +68,60 @@ namespace details {
 
   template<typename E, typename StringLengthType, std::size_t Size>
   struct FinalReflectionResult {
-    std::array<E, Size> values{};
+    details::array<E, Size> values{};
     // +1 for easier iteration on on last string
-    std::array<StringLengthType, Size + 1> string_indices{};
+    details::array<StringLengthType, Size + 1> string_indices{};
   };
 
-  template<typename E, bool NullTerminated, auto Min = enum_traits<E>::min, decltype(Min) Max = enum_traits<E>::max>
-  inline constexpr auto reflection_data_impl = details::reflect<E, NullTerminated, Min>(
+  template<typename E,
+           bool NullTerminated,
+           typename T = typename std::underlying_type<E>::type,
+           T Min = static_cast<T>(enum_traits<E>::min),
+           T Max = static_cast<T>(enum_traits<E>::max)>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data_impl = details::reflect<E, NullTerminated, T, Min>(
     std::make_index_sequence<details::get_index_sequence_max(is_bitflag<E>,
-                                                             has_fixed_underlying_type<E>,
-                                                             sizeof(E),
-                                                             Min,
-                                                             Max,
-                                                             std::is_signed_v<std::underlying_type_t<E>>)>{});
+                                                              has_fixed_underlying_type<E>,
+                                                              sizeof(E),
+                                                              Min,
+                                                              Max,
+                                                               std::is_signed<T>::value)>{});
 
 
-  template<typename E, auto Min, decltype(Min) Max>
-  inline constexpr bool has_a_value_in = details::is_out_of_range<E, Min>(
+  template<typename E,
+           typename T = typename std::underlying_type<E>::type,
+           T Min = static_cast<T>(enum_traits<E>::min),
+           T Max = static_cast<T>(enum_traits<E>::max)>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_a_value_in = details::is_out_of_range<E, T, Min>(
     std::make_index_sequence<
-      details::get_index_sequence_max(false, has_fixed_underlying_type<E>, sizeof(E), Min, Max, std::is_signed_v<std::underlying_type_t<E>>)>{});
+      details::get_index_sequence_max(false, has_fixed_underlying_type<E>, sizeof(E), Min, Max, std::is_signed<T>::value)>{});
 
 
   // Thanks https://en.cppreference.com/w/cpp/utility/intcmp.html
   template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::true_type, std::false_type) noexcept
+  {
+    return t < u;
+  }
+
+  template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::false_type, std::true_type) noexcept
+  {
+    return t < 0 || std::make_unsigned_t<T>(t) < u;
+  }
+
+  template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::false_type, std::false_type) noexcept
+  {
+    return u >= 0 && t < std::make_unsigned_t<U>(u);
+  }
+
+  template<typename T, typename U>
   constexpr bool cmp_less(const T t, const U u) noexcept
   {
-    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
-      return t < u;
-    else if constexpr (std::is_signed_v<T>)
-      return t < 0 || std::make_unsigned_t<T>(t) < u;
-    else
-      return u >= 0 && t < std::make_unsigned_t<U>(u);
+    return details::cmp_less_impl(t,
+                                  u,
+                                  std::integral_constant<bool, std::is_signed<T>::value == std::is_signed<U>::value>{},
+                                  std::integral_constant<bool, std::is_signed<T>::value>{});
   }
 
   template<typename U>
@@ -126,62 +148,113 @@ namespace details {
       return (L::min)();
     return T(u);
   }
+
+  template<typename E, bool NullTerminated, typename T, T Min, T ScaleMin, bool MinIsNegative>
+  struct lower_out_of_bounds_checker {
+    static constexpr void check() noexcept
+    {
+      static_assert(!has_a_value_in<E, T, ScaleMin, Min - 1>,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min, T ScaleMin>
+  struct lower_out_of_bounds_checker<E, NullTerminated, T, Min, ScaleMin, false> {
+    static constexpr void check() noexcept
+    {
+      static_assert(!has_a_value_in<E, T, Min + 1, ScaleMin>,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min, bool CanCheckLower>
+  struct maybe_lower_out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min>
+  struct maybe_lower_out_of_bounds_checker<E, NullTerminated, T, Min, true> {
+    static constexpr void check() noexcept
+    {
+      constexpr auto scale = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      lower_out_of_bounds_checker<E, NullTerminated, T, Min, Min * scale, (Min < 0)>::check();
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Max, bool CanCheckUpper>
+  struct upper_out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Max>
+  struct upper_out_of_bounds_checker<E, NullTerminated, T, Max, true> {
+    static constexpr void check() noexcept
+    {
+      constexpr auto scale           = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      constexpr bool upper_has_value = has_a_value_in<E, T, Max + 1, Max * scale>;
+      static_assert(!upper_has_value,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+      constexpr auto min             = static_cast<T>(enum_traits<E>::min);
+      constexpr auto tmin            = std::numeric_limits<T>::min();
+      constexpr bool can_check_lower = !upper_has_value && min > tmin && min >= tmin / scale;
+      maybe_lower_out_of_bounds_checker<E, NullTerminated, T, min, can_check_lower>::check();
+    }
+  };
+
+  template<typename E, bool NullTerminated, std::size_t ValidCount, bool ShouldCheck>
+  struct out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, std::size_t ValidCount>
+  struct out_of_bounds_checker<E, NullTerminated, ValidCount, true> {
+    static constexpr void check() noexcept
+    {
+#if defined(__NVCOMPILER) || defined(__RESHARPER__)
+      static_assert(ValidCount == reflection_data_impl<E, NullTerminated, typename std::underlying_type<E>::type,
+        details::ClampToRange<typename std::underlying_type<E>::type>(enum_traits<E>::min * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY),
+        details::ClampToRange<typename std::underlying_type<E>::type>(enum_traits<E>::max * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY)
+      >.elements.valid_count,
+          "enchantum has detected that this enum is not fully reflected. Please look at "
+          "https://github.com/ZXShady/enchantum/blob/main/docs/"
+          "features.md#enchantum_check_out_of_bounds_by "
+          "for more information");
+#else
+      using T                        = std::underlying_type_t<E>;
+      constexpr auto max             = static_cast<T>(enum_traits<E>::max);
+      constexpr auto scale           = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      constexpr auto tmax            = std::numeric_limits<T>::max();
+      constexpr bool can_check_upper = max < tmax && max <= tmax / scale;
+      upper_out_of_bounds_checker<E, NullTerminated, T, max, can_check_upper>::check();
+#endif
+    }
+  };
+
   template<typename E, bool NullTerminated>
   constexpr auto get_reflection_data() noexcept
   {
     constexpr auto elements = reflection_data_impl<E, NullTerminated>.elements;
     using StringLengthType = std::conditional_t<(elements.total_string_length < UINT8_MAX), std::uint8_t, std::uint16_t>;
 #if ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY >= 2
-    if constexpr (
-  #if __clang_major__ >= 20
-      has_fixed_underlying_type<E> &&
-  #endif
-      !details::has_specialized_traits<E> && 
-      !is_bitflag<E> && 
-      !std::is_same_v<std::underlying_type_t<E>,bool>) {
-  #define ENCHANTUM_ERROR_STRING                                                    \
-    "enchantum has detected that this enum is not fully reflected. Please look at " \
-    "https://github.com/ZXShady/enchantum/blob/main/docs/"                          \
-    "features.md#enchantum_check_out_of_bounds_by "                                 \
-    "for more information"
-    // TODO: switch to new check for those 2 compilers
-  #if defined(__NVCOMPILER) || defined(__RESHARPER__)
-      static_assert(elements.valid_count == reflection_data_impl<E, NullTerminated,
-        details::ClampToRange<std::underlying_type_t<E>>(enum_traits<E>::min * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY),
-        details::ClampToRange<std::underlying_type_t<E>>(enum_traits<E>::max * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY)
-    >.elements.valid_count,
-          ENCHANTUM_ERROR_STRING);
-  #else
-      // check [min,max] * 2 but exluding [min,max]
-      using T = std::underlying_type_t<E>;
-
-      constexpr auto max = +enum_traits<E>::max;
-
-      constexpr auto scale = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
-
-      constexpr auto tmax = std::numeric_limits<T>::max();
-
-      constexpr bool can_check_upper = max < tmax && max <= tmax / scale;
-
-      if constexpr (can_check_upper) {
-        constexpr bool upper_has_value = has_a_value_in<E, max + 1, max * scale>;
-
-        static_assert(!upper_has_value, ENCHANTUM_ERROR_STRING);
-        constexpr auto min = +enum_traits<E>::min;
-        constexpr auto tmin = std::numeric_limits<T>::min();
-        constexpr bool can_check_lower = min > tmin && min >=tmin / scale;
-        if constexpr (!upper_has_value && can_check_lower) {
-          if constexpr (min < 0)
-            static_assert(!has_a_value_in<E, min * scale, min - 1>, ENCHANTUM_ERROR_STRING);
-          else
-            static_assert(!has_a_value_in<E, min + 1, min * scale>, ENCHANTUM_ERROR_STRING);
-        }
-      }
-  #endif
-    }
+    details::out_of_bounds_checker<E,
+                                   NullTerminated,
+                                   elements.valid_count,
+#if __clang_major__ >= 20
+                                   has_fixed_underlying_type<E> &&
 #endif
-#undef ENCHANTUM_ERROR_STRING
-      
+                                     !details::has_specialized_traits<E> && !is_bitflag<E> &&
+                                     !std::is_same<std::underlying_type_t<E>, bool>::value>::check();
+#endif
+
     FinalReflectionResult<E, StringLengthType, elements.valid_count> ret;
     std::size_t                                                      i            = 0;
     StringLengthType                                                 string_index = 0;
@@ -207,13 +280,42 @@ namespace details {
 
 
   template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_data_string_storage = details::reflection_data_impl<E, NullTerminated>.strings;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data_string_storage = details::reflection_data_impl<E, NullTerminated>.strings;
 
   template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_data = details::get_reflection_data<E, NullTerminated>();
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data = details::get_reflection_data<E, NullTerminated>();
 
   template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_string_indices = reflection_data<E, NullTerminated>.string_indices;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_string_indices = reflection_data<E, NullTerminated>.string_indices;
+
+  template<typename Pair, typename = void>
+  struct has_first_second : std::false_type {
+  };
+
+  template<typename Pair>
+  struct has_first_second<Pair, void_t<decltype(std::declval<Pair&>().first), decltype(std::declval<Pair&>().second)>>
+    : std::true_type {
+  };
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry_impl(Pair& entry, E value, const char* string, std::size_t size, std::true_type)
+  {
+    using StringView = typename std::remove_cv<typename std::remove_reference<decltype(entry.second)>::type>::type;
+    entry.first      = value;
+    entry.second     = StringView(string, size);
+  }
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry_impl(Pair& entry, E value, const char* string, std::size_t size, std::false_type)
+  {
+    entry = Pair{value, string_view(string, size)};
+  }
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry(Pair& entry, E value, const char* string, std::size_t size)
+  {
+    assign_entry_impl(entry, value, string, size, has_first_second<Pair>{});
+  }
 
   template<typename E, typename Pair, bool NullTerminated, typename Reflected = int>
   constexpr auto get_entries()
@@ -226,7 +328,7 @@ namespace details {
     constexpr auto reflected = details::reflection_data<std::remove_cv_t<E>, NullTerminated>;
     constexpr auto strings   = details::reflection_data_string_storage<std::remove_cv_t<E>, NullTerminated>.data();
 #endif
-    constexpr auto size = sizeof(reflected.values) / sizeof(reflected.values[0]);
+    constexpr auto size = reflected.values.size();
     static_assert(size != 0,
                   "enchantum failed to reflect this enum.\n"
                   "Please read https://github.com/ZXShady/enchantum/blob/main/docs/limitations.md before opening an "
@@ -242,14 +344,11 @@ namespace details {
                                                                              indices[1] - indices[0] - NullTerminated)},
                                                             std::make_index_sequence<size>{});
 #else
-    std::array<Pair, size> ret{};
+    details::array<Pair, size> ret{};
 #endif
     auto* const ret_data = ret.data();
     for (std::size_t i = 0; i < size; ++i) {
-      auto& [e, s]     = ret_data[i];
-      e                = reflected.values[i];
-      using StringView = std::remove_cv_t<std::remove_reference_t<decltype(s)>>;
-      s                = StringView(strings + indices[i], indices[i + 1] - indices[i] - NullTerminated);
+      assign_entry(ret_data[i], reflected.values[i], strings + indices[i], indices[i + 1] - indices[i] - NullTerminated);
     }
     return ret;
   }
@@ -261,16 +360,16 @@ template<Enum E, typename Pair = std::pair<E, enchantum::string_view>, bool Null
 template<typename E,
          typename Pair                            = std::pair<E, enchantum::string_view>,
          bool NullTerminated                      = true,
-         std::enable_if_t<std::is_enum_v<E>, int> = 0>
+          std::enable_if_t<std::is_enum<E>::value, int> = 0>
 #endif
-inline constexpr auto entries = enchantum::details::get_entries<E, Pair, NullTerminated>();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto entries = enchantum::details::get_entries<E, Pair, NullTerminated>();
 
 namespace details {
   template<typename E>
   constexpr auto get_values() noexcept
   {
     constexpr auto              enums = entries<E>;
-    std::array<E, enums.size()> ret{};
+    details::array<E, enums.size()> ret{};
     const auto* const           enums_data = enums.data();
     for (std::size_t i = 0; i < ret.size(); ++i)
       ret[i] = enums_data[i].first;
@@ -281,7 +380,7 @@ namespace details {
   constexpr auto get_names() noexcept
   {
     constexpr auto                   enums = entries<E, std::pair<E, String>, NullTerminated>;
-    std::array<String, enums.size()> ret{};
+    details::array<String, enums.size()> ret{};
     const auto* const                enums_data = enums.data();
     for (std::size_t i = 0; i < ret.size(); ++i)
       ret[i] = enums_data[i].second;
@@ -291,65 +390,90 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto values = details::get_values<E>();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto values = details::get_values<E>();
 
 #ifdef __cpp_concepts
 template<Enum E, typename String = string_view, bool NullTerminated = true>
 #else
-template<typename E, typename String = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+template<typename E, typename String = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
 #endif
-inline constexpr auto names = details::get_names<E, String, NullTerminated>();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto names = details::get_names<E, String, NullTerminated>();
 
 
-#define ENCHANTUM_DECLARE_EMPTY(ENUM)                                                                         \
-  template<>                                                                                                  \
-  inline constexpr auto enchantum::entries<ENUM> = ::std::array<std::pair<ENUM, ::enchantum::string_view>, 0> \
-  {                                                                                                           \
+#define ENCHANTUM_DECLARE_EMPTY(ENUM)                                                                                         \
+  template<>                                                                                                                  \
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto enchantum::entries<ENUM> = ::enchantum::details::array<std::pair<ENUM, ::enchantum::string_view>, 0> \
+  {                                                                                                                           \
   }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto min = entries<E>.front().first;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto min = entries<E>.front().first;
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto max = entries<E>.back().first;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto max = entries<E>.back().first;
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr std::size_t count = entries<E>.size();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr std::size_t count = entries<E>.size();
+
+namespace details {
+  template<typename E, bool IsBitflag>
+  struct has_zero_flag_impl {
+    static constexpr bool value() noexcept { return false; }
+  };
+
+  template<typename E>
+  struct has_zero_flag_impl<E, true> {
+    static constexpr bool value() noexcept
+    {
+      for (const auto v : values<E>)
+        if (static_cast<typename std::underlying_type<E>::type>(v) == 0)
+          return true;
+      return false;
+    }
+  };
+
+  template<typename E, bool IsBitflag>
+  struct is_contiguous_bitflag_impl {
+    static constexpr bool value() noexcept { return false; }
+  };
+
+  template<typename E>
+  struct is_contiguous_bitflag_impl<E, true> {
+    static constexpr bool value() noexcept
+    {
+      constexpr auto& enums = entries<E>;
+      using T               = typename std::underlying_type<E>::type;
+      std::size_t i = static_cast<std::size_t>(has_zero_flag_impl<E, true>::value());
+      for (; i < enums.size() - 1; ++i)
+        if (T(enums[i].first) << 1 != T(enums[i + 1].first))
+          return false;
+      return true;
+    }
+  };
+
+  template<typename E, bool Empty>
+  struct is_contiguous_impl {
+    static constexpr bool value() noexcept
+    {
+      return static_cast<std::size_t>(enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) + 1 == count<E>;
+    }
+  };
+
+  template<typename E>
+  struct is_contiguous_impl<E, true> {
+    static constexpr bool value() noexcept { return false; }
+  };
+} // namespace details
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = details::has_zero_flag_impl<E, is_bitflag<E>>::value();
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = details::is_contiguous_impl<E, count<E> == 0>::value();
 
 
 template<typename E>
-inline constexpr bool has_zero_flag = [](const auto is_bitflag) {
-  if constexpr (is_bitflag.value) {
-    for (const auto v : values<E>)
-      if (static_cast<std::underlying_type_t<E>>(v) == 0)
-        return true;
-  }
-  return false;
-}(std::bool_constant<is_bitflag<E>>{});
-
-template<typename E>
-inline constexpr bool is_contiguous = []() {
-  if constexpr (count<E> == 0)
-    return false;
-  else
-    return static_cast<std::size_t>(enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) + 1 == count<E>;
-}();
-
-
-template<typename E>
-inline constexpr bool is_contiguous_bitflag = [](const auto is_bitflag) {
-  if constexpr (is_bitflag.value) {
-    constexpr auto& enums = entries<E>;
-    using T               = std::underlying_type_t<E>;
-    for (auto i = std::size_t{has_zero_flag<E>}; i < enums.size() - 1; ++i)
-      if (T(enums[i].first) << 1 != T(enums[i + 1].first))
-        return false;
-    return true;
-  }
-  else {
-    return false;
-  }
-}(std::bool_constant<is_bitflag<E>>{});
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = details::is_contiguous_bitflag_impl<E, is_bitflag<E>>::value();
 
 #ifdef __cpp_concepts
 template<typename E>

--- a/enchantum/include/enchantum/entries.hpp
+++ b/enchantum/include/enchantum/entries.hpp
@@ -425,8 +425,9 @@ namespace details {
   struct has_zero_flag_impl<E, true> {
     static constexpr bool value() noexcept
     {
-      for (const auto v : values<E>)
-        if (static_cast<typename std::underlying_type<E>::type>(v) == 0)
+      constexpr auto& vals = values<E>;
+      for (std::size_t i = 0; i < vals.size(); ++i)
+        if (static_cast<typename std::underlying_type<E>::type>(vals[i]) == 0)
           return true;
       return false;
     }

--- a/enchantum/include/enchantum/fmt_format.hpp
+++ b/enchantum/include/enchantum/fmt_format.hpp
@@ -10,7 +10,7 @@ template<enchantum::Enum E>
 struct fmt::formatter<E>
 #else
 template<typename E>
-struct fmt::formatter<E, char, std::enable_if_t<std::is_enum_v<E>>>
+struct fmt::formatter<E, char, std::enable_if_t<std::is_enum<E>::value>>
 #endif
 : fmt::formatter<string_view> {
   template<typename FmtContext>

--- a/enchantum/include/enchantum/generators.hpp
+++ b/enchantum/include/enchantum/generators.hpp
@@ -50,94 +50,94 @@ namespace details {
       return static_cast<CRTP&>(*this);
     }
 
-    [[nodiscard]] constexpr CRTP operator++(int) & noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr CRTP operator++(int) & noexcept
     {
       auto copy = static_cast<CRTP&>(*this);
       ++*this;
       return copy;
     }
-    [[nodiscard]] constexpr CRTP operator--(int) & noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr CRTP operator--(int) & noexcept
     {
       auto copy = static_cast<CRTP&>(*this);
       --*this;
       return copy;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator+(CRTP it, const std::ptrdiff_t offset) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator+(CRTP it, const std::ptrdiff_t offset) noexcept
     {
       it += offset;
       return it;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator+(const std::ptrdiff_t offset, CRTP it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator+(const std::ptrdiff_t offset, CRTP it) noexcept
     {
       it += offset;
       return it;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator-(CRTP it, const std::ptrdiff_t offset) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator-(CRTP it, const std::ptrdiff_t offset) noexcept
     {
       it -= offset;
       return it;
     }
 
-    [[nodiscard]] constexpr std::ptrdiff_t operator-(const sized_iterator that) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr std::ptrdiff_t operator-(const sized_iterator that) const noexcept
     {
       return index - that.index;
     }
 
-    [[nodiscard]] constexpr std::ptrdiff_t        operator-(senitiel) const noexcept { return index - Size; }
-    [[nodiscard]] friend constexpr std::ptrdiff_t operator-(senitiel, sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr std::ptrdiff_t        operator-(senitiel) const noexcept { return index - Size; }
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr std::ptrdiff_t operator-(senitiel, sized_iterator it) noexcept
     {
       return Size - it.index;
     }
 
-    [[nodiscard]] constexpr bool operator==(const sized_iterator that) const noexcept { return that.index == index; };
-    [[nodiscard]] constexpr bool operator==(senitiel) const noexcept { return Size == index; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator==(const sized_iterator that) const noexcept { return that.index == index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator==(senitiel) const noexcept { return Size == index; }
 
 #ifdef __cpp_impl_three_way_comparison
-    [[nodiscard]] constexpr auto operator<=>(const sized_iterator that) const noexcept { return index <=> that.index; };
-    [[nodiscard]] constexpr auto operator<=>(senitiel) const noexcept { return index <=> Size; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator<=>(const sized_iterator that) const noexcept { return index <=> that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator<=>(senitiel) const noexcept { return index <=> Size; }
 #else
 
-    [[nodiscard]] constexpr bool operator!=(const sized_iterator that) const noexcept { return that.index != index; };
-    [[nodiscard]] constexpr bool operator!=(senitiel) const noexcept { return Size != index; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator!=(const sized_iterator that) const noexcept { return that.index != index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator!=(senitiel) const noexcept { return Size != index; }
 
-    [[nodiscard]] friend constexpr bool operator==(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator==(senitiel, const sized_iterator it) noexcept
     {
       return Size == it.index;
     }
 
 
-    [[nodiscard]] friend constexpr bool operator!=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator!=(senitiel, const sized_iterator it) noexcept
     {
       return Size != it.index;
     }
 
 
-    [[nodiscard]] constexpr bool operator<(const sized_iterator that) const noexcept { return index < that.index; };
-    [[nodiscard]] constexpr bool operator>(const sized_iterator that) const noexcept { return index > that.index; };
-    [[nodiscard]] constexpr bool operator<=(const sized_iterator that) const noexcept { return index <= that.index; };
-    [[nodiscard]] constexpr bool operator>=(const sized_iterator that) const noexcept { return index >= that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<(const sized_iterator that) const noexcept { return index < that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>(const sized_iterator that) const noexcept { return index > that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<=(const sized_iterator that) const noexcept { return index <= that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>=(const sized_iterator that) const noexcept { return index >= that.index; };
 
-    [[nodiscard]] constexpr bool operator<(senitiel) const noexcept { return index < Size; };
-    [[nodiscard]] constexpr bool operator>(senitiel) const noexcept { return index > Size; };
-    [[nodiscard]] constexpr bool operator<=(senitiel) const noexcept { return index <= Size; };
-    [[nodiscard]] constexpr bool operator>=(senitiel) const noexcept { return index >= Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<(senitiel) const noexcept { return index < Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>(senitiel) const noexcept { return index > Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<=(senitiel) const noexcept { return index <= Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>=(senitiel) const noexcept { return index >= Size; };
 
-    [[nodiscard]] friend constexpr bool operator<(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator<(senitiel, const sized_iterator it) noexcept
     {
       return Size < it.index;
     };
-    [[nodiscard]] friend constexpr bool operator>(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator>(senitiel, const sized_iterator it) noexcept
     {
       return Size > it.index;
     };
-    [[nodiscard]] friend constexpr bool operator<=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator<=(senitiel, const sized_iterator it) noexcept
     {
       return Size <= it.index;
     };
-    [[nodiscard]] friend constexpr bool operator>=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator>=(senitiel, const sized_iterator it) noexcept
     {
       return Size >= it.index;
     };
@@ -147,20 +147,20 @@ namespace details {
 
   template<typename E, typename String = string_view, bool NullTerminated = true>
   struct names_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = String;
       using base::operator+=;
-      [[nodiscard]] constexpr String operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator*() const noexcept
       {
         const auto* const p       = details::reflection_string_indices<E, NullTerminated>.data();
         const auto* const strings = details::reflection_data_string_storage<E, NullTerminated>.data();
         return String(strings + p[this->index], p[this->index + 1] - p[this->index] - NullTerminated);
       }
 
-      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -168,10 +168,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);
@@ -181,19 +181,19 @@ namespace details {
 
   template<typename E>
   struct values_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
       using base::operator+=;
-      [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
         return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
       }
 
-      [[nodiscard]] constexpr E dereference(std::false_type, std::true_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::false_type, std::true_type) const noexcept
       {
         using T                        = typename std::underlying_type<E>::type;
         using UT                       = typename std::make_unsigned<T>::type;
@@ -203,17 +203,17 @@ namespace details {
         return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
       }
 
-      [[nodiscard]] constexpr E dereference(std::false_type, std::false_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::false_type, std::false_type) const noexcept
       {
         return values<E>[static_cast<std::size_t>(this->index)];
       }
 
-      [[nodiscard]] constexpr E operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E operator*() const noexcept
       {
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
-      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -221,10 +221,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);
@@ -234,20 +234,20 @@ namespace details {
 
   template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true>
   struct entries_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = Pair;
       using base::operator+=;
-      [[nodiscard]] constexpr Pair operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr Pair operator*() const noexcept
       {
         return Pair{
           values_generator_t<E>{}[static_cast<std::size_t>(this->index)],
           names_generator_t<E, string_view, NullTerminated>{}[static_cast<std::size_t>(this->index)],
         };
       }
-      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -255,10 +255,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);

--- a/enchantum/include/enchantum/generators.hpp
+++ b/enchantum/include/enchantum/generators.hpp
@@ -187,6 +187,7 @@ namespace details {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
       using base::operator+=;
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
       ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
@@ -207,11 +208,30 @@ namespace details {
       {
         return values<E>[static_cast<std::size_t>(this->index)];
       }
+#endif
 
       ENCHANTUM_DETAILS_NODISCARD constexpr E operator*() const noexcept
       {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        if constexpr (is_contiguous<E>) {
+          using T = typename std::underlying_type<E>::type;
+          return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
+        }
+        else if constexpr (is_contiguous_bitflag<E>) {
+          using T                        = typename std::underlying_type<E>::type;
+          using UT                       = typename std::make_unsigned<T>::type;
+          constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
+          if (has_zero_flag<E> ? this->index == 0 : false)
+            return E{};
+          return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
+        }
+        else {
+          return values<E>[static_cast<std::size_t>(this->index)];
+        }
+#else
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
+#endif
       }
       ENCHANTUM_DETAILS_NODISCARD constexpr E operator[](const std::ptrdiff_t i) const noexcept
       {

--- a/enchantum/include/enchantum/generators.hpp
+++ b/enchantum/include/enchantum/generators.hpp
@@ -158,7 +158,12 @@ namespace details {
         return String(strings + p[this->index], p[this->index + 1] - p[this->index] - NullTerminated);
       }
 
-      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -166,7 +171,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 
@@ -202,7 +209,12 @@ namespace details {
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
-      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -210,7 +222,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 
@@ -227,7 +241,12 @@ namespace details {
           names_generator_t<E, string_view, NullTerminated>{}[static_cast<std::size_t>(this->index)],
         };
       }
-      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -235,7 +254,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 

--- a/enchantum/include/enchantum/generators.hpp
+++ b/enchantum/include/enchantum/generators.hpp
@@ -150,7 +150,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = String;
+      using base::operator+=;
       [[nodiscard]] constexpr String operator*() const noexcept
       {
         const auto* const p       = details::reflection_string_indices<E, NullTerminated>.data();
@@ -182,7 +184,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
+      using base::operator+=;
       [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
@@ -233,7 +237,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = Pair;
+      using base::operator+=;
       [[nodiscard]] constexpr Pair operator*() const noexcept
       {
         return Pair{

--- a/enchantum/include/enchantum/generators.hpp
+++ b/enchantum/include/enchantum/generators.hpp
@@ -176,25 +176,31 @@ namespace details {
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using value_type = E;
+      [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
+      {
+        using T = typename std::underlying_type<E>::type;
+        return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
+      }
+
+      [[nodiscard]] constexpr E dereference(std::false_type, std::true_type) const noexcept
+      {
+        using T                        = typename std::underlying_type<E>::type;
+        using UT                       = typename std::make_unsigned<T>::type;
+        constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
+        if (has_zero_flag<E> ? this->index == 0 : false)
+          return E{};
+        return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
+      }
+
+      [[nodiscard]] constexpr E dereference(std::false_type, std::false_type) const noexcept
+      {
+        return values<E>[static_cast<std::size_t>(this->index)];
+      }
+
       [[nodiscard]] constexpr E operator*() const noexcept
       {
-        using T = std::underlying_type_t<E>;
-
-        if constexpr (is_contiguous<E>) {
-          return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
-        }
-        else if constexpr (is_contiguous_bitflag<E>) {
-          using UT                       = std::make_unsigned_t<T>;
-          constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
-
-          if constexpr (has_zero_flag<E>)
-            if (this->index == 0)
-              return E{};
-          return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
-        }
-        else {
-          return values<E>[static_cast<std::size_t>(this->index)];
-        }
+        return dereference(std::integral_constant<bool, is_contiguous<E>>{},
+                           std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
       [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
     };
@@ -236,21 +242,21 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::values_generator_t<E> values_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::values_generator_t<E> values_generator{};
 
 #ifdef __cpp_concepts
 template<Enum E, typename StringView = string_view, bool NullTerminated = true>
-inline constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
 
 template<Enum E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true>
-inline constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
 
 #else
-template<typename E, typename StringView = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
-inline constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
+template<typename E, typename StringView = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
 
-template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
-inline constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
+template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
 
 #endif
 

--- a/enchantum/include/enchantum/iostream.hpp
+++ b/enchantum/include/enchantum/iostream.hpp
@@ -8,6 +8,26 @@
 
 namespace enchantum {
 namespace iostream_operators {
+  template<typename E>
+  bool extract_enum_from_string(const std::string& s, E& value, std::true_type)
+  {
+    if (const auto v = enchantum::cast_bitflag<E>(s)) {
+      value = *v;
+      return true;
+    }
+    return false;
+  }
+
+  template<typename E>
+  bool extract_enum_from_string(const std::string& s, E& value, std::false_type)
+  {
+    if (const auto v = enchantum::cast<E>(s)) {
+      value = *v;
+      return true;
+    }
+    return false;
+  }
+
   template<typename Traits, ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   std::basic_ostream<char, Traits>& operator<<(std::basic_ostream<char, Traits>& os, const E e)
   {
@@ -23,18 +43,8 @@ namespace iostream_operators {
     if (!is)
       return is;
 
-    if constexpr (is_bitflag<E>) {
-      if (const auto v = enchantum::cast_bitflag<E>(s))
-        value = *v;
-      else
-        is.setstate(std::ios_base::failbit);
-    }
-    else {
-      if (const auto v = enchantum::cast<E>(s))
-        value = *v;
-      else
-        is.setstate(std::ios_base::failbit);
-    }
+    if (!extract_enum_from_string(s, value, std::integral_constant<bool, is_bitflag<E>>{}))
+      is.setstate(std::ios_base::failbit);
     return is;
   }
 } // namespace iostream_operators

--- a/enchantum/include/enchantum/iostream.hpp
+++ b/enchantum/include/enchantum/iostream.hpp
@@ -8,20 +8,20 @@
 
 namespace enchantum {
 namespace iostream_operators {
-  template<typename E>
-  bool extract_enum_from_string(const std::string& s, E& value, std::true_type)
+  template<typename String, typename E>
+  bool extract_enum_from_string(const String& s, E& value, std::true_type)
   {
-    if (const auto v = enchantum::cast_bitflag<E>(s)) {
+    if (const auto v = enchantum::cast_bitflag<E>(string_view(s.data(), s.size()))) {
       value = *v;
       return true;
     }
     return false;
   }
 
-  template<typename E>
-  bool extract_enum_from_string(const std::string& s, E& value, std::false_type)
+  template<typename String, typename E>
+  bool extract_enum_from_string(const String& s, E& value, std::false_type)
   {
-    if (const auto v = enchantum::cast<E>(s)) {
+    if (const auto v = enchantum::cast<E>(string_view(s.data(), s.size()))) {
       value = *v;
       return true;
     }

--- a/enchantum/include/enchantum/next_value.hpp
+++ b/enchantum/include/enchantum/next_value.hpp
@@ -16,7 +16,7 @@ namespace details {
   template<std::ptrdiff_t N>
   struct next_value_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       if (!enchantum::contains(value))
         return optional<E>();
@@ -31,7 +31,7 @@ namespace details {
   template<std::ptrdiff_t N>
   struct next_value_circular_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr E operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr E operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       ENCHANTUM_ASSERT(enchantum::contains(value), "next/prev_value_circular requires 'value' to be a valid enum member", value);
       const auto     i     = static_cast<std::ptrdiff_t>(*enchantum::enum_to_index(value));

--- a/enchantum/include/enchantum/next_value.hpp
+++ b/enchantum/include/enchantum/next_value.hpp
@@ -19,12 +19,12 @@ namespace details {
     [[nodiscard]] constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       if (!enchantum::contains(value))
-        return optional<E>{};
+        return optional<E>();
 
       const auto index = static_cast<std::ptrdiff_t>(*enchantum::enum_to_index(value)) + (n * N);
       if (index >= 0 && index < static_cast<std::ptrdiff_t>(count<E>))
-        return optional<E>{values_generator<E>[static_cast<std::size_t>(index)]};
-      return optional<E>{};
+        return optional<E>(values_generator<E>[static_cast<std::size_t>(index)]);
+      return optional<E>();
     }
   };
 

--- a/enchantum/include/enchantum/next_value.hpp
+++ b/enchantum/include/enchantum/next_value.hpp
@@ -42,10 +42,10 @@ namespace details {
 } // namespace details
 
 
-inline constexpr details::next_value_functor<1>           next_value{};
-inline constexpr details::next_value_functor<-1>          prev_value{};
-inline constexpr details::next_value_circular_functor<1>  next_value_circular{};
-inline constexpr details::next_value_circular_functor<-1> prev_value_circular{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_functor<1>           next_value{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_functor<-1>          prev_value{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_circular_functor<1>  next_value_circular{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_circular_functor<-1> prev_value_circular{};
 
 } // namespace enchantum
 

--- a/enchantum/include/enchantum/scoped.hpp
+++ b/enchantum/include/enchantum/scoped.hpp
@@ -21,11 +21,10 @@ namespace scoped {
 
     constexpr string_view remove_scope_or_empty(string_view string, const string_view type_name) noexcept
     {
-      const auto starts_with = [](auto a, auto b) { return a.substr(0, b.size()) == b; };
-      if (!starts_with(string, type_name))
+      if (string.substr(0, type_name.size()) != type_name)
         return string_view();
       string.remove_prefix(type_name.size());
-      if (!starts_with(string, string_view("::", 2)))
+      if (string.substr(0, 2) != string_view("::", 2))
         return string_view();
       string.remove_prefix(2);
       return string;
@@ -52,14 +51,14 @@ namespace scoped {
       [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
-        return n.empty() ? optional<E>() : cast<E>(n);
+        return n.empty() ? optional<E>() : enchantum::cast<E>(n);
       }
 
       template<typename BinaryPred>
       [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
-        return n.empty() ? optional<E>() : cast<E>(n, binary_predicate);
+        return n.empty() ? optional<E>() : enchantum::cast<E>(n, binary_predicate);
       }
     };
 
@@ -70,9 +69,11 @@ namespace scoped {
       {
         String s;
         if (const auto i = enchantum::enum_to_index(value)) {
-          s += type_name<E>;
-          s += "::";
-          s += names_generator<E>[*i];
+          const auto scope_name = type_name<E>;
+          s.append(scope_name.data(), scope_name.size());
+          s.append("::", 2);
+          const auto name = names_generator<E>[*i];
+          s.append(name.data(), name.size());
           return s;
         }
         return s;
@@ -81,10 +82,10 @@ namespace scoped {
   } // namespace details
 
 
-  inline constexpr details::to_scoped_string_functor to_string;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr details::to_scoped_string_functor to_string;
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  inline constexpr details::scoped_cast_functor<E> cast;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr details::scoped_cast_functor<E> cast;
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
   [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
@@ -115,14 +116,14 @@ namespace scoped {
   [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
   {
     using T = std::underlying_type_t<E>;
-    if constexpr (has_zero_flag<E>)
+    if (has_zero_flag<E>)
       if (static_cast<T>(value) == 0)
         return enchantum::scoped::to_string(value);
 
     String         name;
     T              check_value = 0;
     constexpr auto scope_name  = type_name<E>;
-    for (auto i = std::size_t{has_zero_flag<E>}; i < count<E>; ++i) {
+    for (auto i = static_cast<std::size_t>(has_zero_flag<E>); i < count<E>; ++i) {
       const auto v = static_cast<T>(values_generator<E>[i]);
       if (v == (static_cast<T>(value) & v)) {
         if (!name.empty())
@@ -130,7 +131,7 @@ namespace scoped {
         name.append(scope_name.data(), scope_name.size());
         name.append("::", 2);
         const auto s = names_generator<E>[i];
-        name.append(s.data(), s.size()); // not using operator += since this may not be std::string_view always
+        name.append(s.data(), s.size());
         check_value |= v;
       }
     }
@@ -162,7 +163,7 @@ namespace scoped {
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
   [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
   {
-    return enchantum::scoped::cast_bitflag<E>(s, sep, [](const auto& a, const auto& b) { return a == b; });
+    return enchantum::scoped::cast_bitflag<E>(s, sep, enchantum::details::equal_to_string_view{});
   }
 } // namespace scoped
 } // namespace enchantum

--- a/enchantum/include/enchantum/scoped.hpp
+++ b/enchantum/include/enchantum/scoped.hpp
@@ -32,14 +32,14 @@ namespace scoped {
   } // namespace details
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr bool contains(const string_view name) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name) noexcept
   {
     const auto n = details::remove_scope_or_empty(name, type_name<E>);
     return !n.empty() && enchantum::contains<E>(n);
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPredicate>
-  [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPredicate binary_predicate) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name, const BinaryPredicate binary_predicate) noexcept
   {
     const auto n = details::remove_scope_or_empty(name, type_name<E>);
     return !n.empty() && enchantum::contains<E>(n, binary_predicate);
@@ -48,14 +48,14 @@ namespace scoped {
   namespace details {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
     struct scoped_cast_functor {
-      [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
         return n.empty() ? optional<E>() : enchantum::cast<E>(n);
       }
 
       template<typename BinaryPred>
-      [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
         return n.empty() ? optional<E>() : enchantum::cast<E>(n, binary_predicate);
@@ -65,7 +65,7 @@ namespace scoped {
     struct to_scoped_string_functor {
       // hacky workaround about string not being a literal type.
       template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename String = string>
-      [[nodiscard]] constexpr String operator()(const E value) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator()(const E value) const noexcept
       {
         String s;
         if (const auto i = enchantum::enum_to_index(value)) {
@@ -88,7 +88,7 @@ namespace scoped {
   ENCHANTUM_DETAILS_INLINE_VAR constexpr details::scoped_cast_functor<E> cast;
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
   {
     std::size_t pos = 0;
     for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -100,7 +100,7 @@ namespace scoped {
   }
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
   {
     std::size_t pos = 0;
     for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -113,7 +113,7 @@ namespace scoped {
 
 
   template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-  [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
+  ENCHANTUM_DETAILS_NODISCARD constexpr String to_string_bitflag(const E value, const char sep = '|')
   {
     using T = std::underlying_type_t<E>;
     if (has_zero_flag<E>)
@@ -142,7 +142,7 @@ namespace scoped {
 
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-  [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
   {
     using T = std::underlying_type_t<E>;
     T           check_value{};
@@ -161,7 +161,7 @@ namespace scoped {
   }
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-  [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
   {
     return enchantum::scoped::cast_bitflag<E>(s, sep, enchantum::details::equal_to_string_view{});
   }

--- a/enchantum/include/enchantum/type_name.hpp
+++ b/enchantum/include/enchantum/type_name.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "details/string_view.hpp"
-#include <array>
 #include <cstddef>
 
 namespace enchantum {
@@ -9,7 +8,8 @@ namespace details {
 #define SZC(x) (sizeof(x) - 1)
   constexpr string_view extract_name_from_type_name(const string_view type_name) noexcept
   {
-    if (const auto n = type_name.rfind(':'); n != type_name.npos)
+    const auto n = type_name.rfind(':');
+    if (n != type_name.npos)
       return type_name.substr(n + 1);
     else
       return type_name;
@@ -35,8 +35,8 @@ namespace details {
                                      SZC(">(void) noexcept"));
 
     // clang-format off
-    constexpr auto prefix = std::is_enum_v<T> ? SZC("enum ") : 
-        std::is_class_v<T> ?  SZC("struct ") - (s[0] == 'c') :
+    constexpr auto prefix = std::is_enum<T>::value ? SZC("enum ") :
+        std::is_class<T>::value ?  SZC("struct ") - (s[0] == 'c') :
         0;
 // clang-format on
 #elif defined(__GNUG__)
@@ -46,7 +46,7 @@ namespace details {
                                    SZC(__PRETTY_FUNCTION__) -
                                      SZC("constexpr auto enchantum::details::raw_type_name_func() [with _ = ]"));
 #endif
-    std::array<char, 1 + s.size() - prefix> ret{};
+    details::array<char, 1 + s.size() - prefix> ret{};
     auto* const                             ret_data = ret.data();
     const auto* const                       s_data   = s.data();
 
@@ -56,13 +56,13 @@ namespace details {
   }
 
   template<typename T>
-  inline constexpr auto raw_type_name_func_var = raw_type_name_func<T>();
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto raw_type_name_func_var = raw_type_name_func<T>();
 
 
   template<typename T>
   constexpr auto type_name_func() noexcept
   {
-    static_assert(!std::is_function_v<std::remove_pointer_t<T>> && !std::is_member_function_pointer_v<T>,
+    static_assert(!std::is_function<std::remove_pointer_t<T>>::value && !std::is_member_function_pointer<T>::value,
                   "enchantum::type_name<T> does not work well with function pointers or functions or member function\n"
                   "pointers");
 
@@ -70,26 +70,26 @@ namespace details {
     static_assert(array[array.size() - 2] != '>', "enchantum::type_name<T> does not work well with a templated type");
 
     constexpr auto  s     = details::extract_name_from_type_name(string_view(array.data(), array.size() - 1));
-    std::array<char, s.size() + 1> ret{};
+    details::array<char, s.size() + 1> ret{};
     for (std::size_t i = 0; i < s.size(); ++i)
       ret[i] = s[i];
     return ret;
   }
 
   template<typename T>
-  inline constexpr auto type_name_func_var = type_name_func<T>();
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto type_name_func_var = type_name_func<T>();
 
 #undef SZC
 
 } // namespace details
 
 template<typename T>
-inline constexpr auto type_name = string_view(details::type_name_func_var<T>.data(),
-                                              details::type_name_func_var<T>.size() - 1);
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto type_name = string_view(details::type_name_func_var<T>.data(),
+                                                                    details::type_name_func_var<T>.size() - 1);
 
 template<typename T>
-inline constexpr auto raw_type_name = string_view(details::raw_type_name_func_var<T>.data(),
-                                                  details::raw_type_name_func_var<T>.size() - 1);
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto raw_type_name = string_view(details::raw_type_name_func_var<T>.data(),
+                                                                        details::raw_type_name_func_var<T>.size() - 1);
 
 
 } // namespace enchantum

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -1119,14 +1119,11 @@ namespace details {
 
   constexpr const char* find_char(const char* s, const std::size_t count, const char c) noexcept
   {
-#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
-    return std::char_traits<char>::find(s, count, c);
-#else
-    for (std::size_t i = 0; i < count; ++i)
-      if (s[i] == c)
+    for (std::size_t i = 0; i < count; ++i) {
+      if (s[i] == c || s[i] == '\0')
         return s + i;
+    }
     return nullptr;
-#endif
   }
 
   template<typename E, E... Vs>
@@ -1139,8 +1136,12 @@ namespace details {
   constexpr bool is_out_of_range_parse(const char* str, const std::size_t least_length_when_casting, const std::size_t array_size)
   {
     for (std::size_t index = 0; index < array_size; ++index) {
-      if (*str == '(')
-        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+      if (*str == '(') {
+        const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return false;
+        str = comma + SZC(", ");
+      }
       else
         return true;
     }
@@ -1165,11 +1166,17 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return;
+        str = comma + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(details::find_char(str, UINT8_MAX, ',') - str);
+        const auto comma = details::find_char(str, UINT8_MAX, ',');
+        if (comma == nullptr)
+          return;
+        const auto commapos = static_cast<std::size_t>(comma - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -1178,7 +1185,9 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
-        str += commapos + SZC(", ");
+        if (*comma == '\0')
+          return;
+        str = comma + SZC(", ");
       }
     }
   }
@@ -2004,8 +2013,9 @@ namespace details {
   struct has_zero_flag_impl<E, true> {
     static constexpr bool value() noexcept
     {
-      for (const auto v : values<E>)
-        if (static_cast<typename std::underlying_type<E>::type>(v) == 0)
+      constexpr auto& vals = values<E>;
+      for (std::size_t i = 0; i < vals.size(); ++i)
+        if (static_cast<typename std::underlying_type<E>::type>(vals[i]) == 0)
           return true;
       return false;
     }
@@ -2239,7 +2249,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = String;
+      using base::operator+=;
       [[nodiscard]] constexpr String operator*() const noexcept
       {
         const auto* const p       = details::reflection_string_indices<E, NullTerminated>.data();
@@ -2271,7 +2283,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
+      using base::operator+=;
       [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
@@ -2322,7 +2336,9 @@ namespace details {
     [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
+      using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = Pair;
+      using base::operator+=;
       [[nodiscard]] constexpr Pair operator*() const noexcept
       {
         return Pair{
@@ -2514,8 +2530,10 @@ namespace details {
       return optional<std::size_t>(0); // assumes 0 is the index of value `0`
 
     using U = typename std::make_unsigned<T>::type;
-    return optional<std::size_t>(std::size_t(has_zero) + details::countr_zero(static_cast<U>(e)) -
-                                details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+    const auto value_offset = static_cast<std::size_t>(details::countr_zero(static_cast<U>(e)));
+    const auto base_offset =
+      static_cast<std::size_t>(details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+    return optional<std::size_t>(std::size_t(has_zero) + value_offset - base_offset);
   }
 
   template<typename E>
@@ -2907,10 +2925,10 @@ constexpr auto visit(Func func, Enums... enums) noexcept(noexcept(std::declval<F
 namespace details {
 
   template<typename E, typename Func, std::size_t... I>
-  constexpr auto for_each(Func& f, std::index_sequence<I...>)
+  constexpr void for_each(Func& f, std::index_sequence<I...>)
   {
-    // Clang 13 to 15 says ths syntax is invalid if I dont put more `()`
-    (void)((f(std::integral_constant<E, values<E>[I]> {}), ...));
+    using expander = int[];
+    (void)expander{0, ((void)f(std::integral_constant<E, values<E>[I]> {}), 0)...};
   }
 
 } // namespace details
@@ -2929,7 +2947,7 @@ namespace enchantum {
 
 template<typename E, typename V, typename Container = std::array<V, count<E>>>
 class array : public Container {
-  static_assert(std::is_enum<E>::value);
+  static_assert(std::is_enum<E>::value, "enchantum::array requires an enum type");
 public:
   using container_type = Container;
   using index_type     = E;
@@ -2982,7 +3000,7 @@ namespace details {
 
 template<typename E, typename Container = details::bitset<count<E>>>
 class bitset : public Container {
-  static_assert(std::is_enum<E>::value);
+  static_assert(std::is_enum<E>::value, "enchantum::bitset requires an enum type");
 public:
 
   using container_type = Container;

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -3357,20 +3357,20 @@ namespace scoped {
 
 namespace enchantum {
 namespace iostream_operators {
-  template<typename E>
-  bool extract_enum_from_string(const std::string& s, E& value, std::true_type)
+  template<typename String, typename E>
+  bool extract_enum_from_string(const String& s, E& value, std::true_type)
   {
-    if (const auto v = enchantum::cast_bitflag<E>(s)) {
+    if (const auto v = enchantum::cast_bitflag<E>(string_view(s.data(), s.size()))) {
       value = *v;
       return true;
     }
     return false;
   }
 
-  template<typename E>
-  bool extract_enum_from_string(const std::string& s, E& value, std::false_type)
+  template<typename String, typename E>
+  bool extract_enum_from_string(const String& s, E& value, std::false_type)
   {
-    if (const auto v = enchantum::cast<E>(s)) {
+    if (const auto v = enchantum::cast<E>(string_view(s.data(), s.size()))) {
       value = *v;
       return true;
     }

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -1,7 +1,95 @@
 #pragma once
 
+
+#include <type_traits>
+#include <utility>
+#include <cstddef>
+
+#if defined(_MSVC_LANG)
+  #define ENCHANTUM_DETAILS_CXX_STD _MSVC_LANG
+#else
+  #define ENCHANTUM_DETAILS_CXX_STD __cplusplus
+#endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  #include <array>
+#endif
+
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  #define ENCHANTUM_DETAILS_INLINE_VAR inline
+#else
+  #define ENCHANTUM_DETAILS_INLINE_VAR
+#endif
+
+namespace enchantum {
+namespace details {
+
+template<typename...>
+using void_t = void;
+
+template<bool B>
+using bool_constant = std::integral_constant<bool, B>;
+
+template<typename F, typename... Args>
+struct is_invocable {
+private:
+  template<typename U>
+  static auto test(int) -> decltype(std::declval<U>()(std::declval<Args>()...), std::true_type{});
+
+  template<typename>
+  static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<F>(0))::value;
+};
+
+template<typename T>
+struct type_identity {
+  using type = T;
+};
+
+template<typename T, std::size_t N>
+struct cxx14_array {
+  T elems[N == 0 ? 1 : N]{};
+
+  constexpr T*       data() noexcept { return elems; }
+  constexpr const T* data() const noexcept { return elems; }
+
+  constexpr T&       operator[](std::size_t i) noexcept { return elems[i]; }
+  constexpr const T& operator[](std::size_t i) const noexcept { return elems[i]; }
+
+  constexpr T&       front() noexcept { return elems[0]; }
+  constexpr const T& front() const noexcept { return elems[0]; }
+
+  constexpr T&       back() noexcept { return elems[N == 0 ? 0 : N - 1]; }
+  constexpr const T& back() const noexcept { return elems[N == 0 ? 0 : N - 1]; }
+
+  constexpr T*       begin() noexcept { return elems; }
+  constexpr const T* begin() const noexcept { return elems; }
+
+  constexpr T*       end() noexcept { return elems + N; }
+  constexpr const T* end() const noexcept { return elems + N; }
+
+  constexpr std::size_t size() const noexcept { return N; }
+};
+
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+template<typename T, std::size_t N>
+using array = std::array<T, N>;
+#else
+template<typename T, std::size_t N>
+using array = cxx14_array<T, N>;
+#endif
+
+} // namespace details
+} // namespace enchantum
+
+
 #ifdef ENCHANTUM_CONFIG_FILE
   #include ENCHANTUM_CONFIG_FILE
+#endif
+
+#if !defined(ENCHANTUM_ALIAS_STRING_VIEW) && ENCHANTUM_DETAILS_CXX_STD < 201703L
+  #error "C++14 users must define ENCHANTUM_ALIAS_STRING_VIEW to a string_view-compatible alias."
 #endif
 
 #ifndef ENCHANTUM_ALIAS_STRING_VIEW
@@ -12,100 +100,18 @@ namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_STRING_VIEW
 ENCHANTUM_ALIAS_STRING_VIEW;
 #else
-using ::std::string_view;
+using ::std ::string_view;
 #endif
 
 } // namespace enchantum
-#include <array>
 
-namespace enchantum {
-
-namespace details {
-#define SZC(x) (sizeof(x) - 1)
-  constexpr string_view extract_name_from_type_name(const string_view type_name) noexcept
-  {
-    if (const auto n = type_name.rfind(':'); n != type_name.npos)
-      return type_name.substr(n + 1);
-    else
-      return type_name;
-  }
-
-  template<typename T>
-  constexpr auto raw_type_name_func() noexcept
-  {
-#if defined(__NVCOMPILER)
-    constexpr std::size_t prefix = 0;
-    constexpr auto s = string_view(__PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::raw_type_name_func() noexcept [with T = "),
-            SZC(__PRETTY_FUNCTION__) - SZC("constexpr auto enchantum::details::raw_type_name_func() noexcept [with T = ]"));
-#elif defined(__clang__)
-    constexpr std::size_t prefix = 0;
-    constexpr auto s = string_view(__PRETTY_FUNCTION__ + SZC("auto enchantum::details::raw_type_name_func() [_ = "),
-                                   SZC(__PRETTY_FUNCTION__) - SZC("auto enchantum::details::raw_type_name_func() [_ = ]"));
-#elif defined(_MSC_VER)
-    constexpr auto s = string_view(__FUNCSIG__ + SZC("auto __cdecl enchantum::details::raw_type_name_func<"),
-                                   SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::raw_type_name_func<") -
-                                     SZC(">(void) noexcept"));
-
-    // clang-format off
-    constexpr auto prefix = std::is_enum_v<T> ? SZC("enum ") : 
-        std::is_class_v<T> ?  SZC("struct ") - (s[0] == 'c') :
-        0;
-// clang-format on
-#elif defined(__GNUG__)
-    constexpr std::size_t prefix = 0;
-    constexpr auto        s      = string_view(__PRETTY_FUNCTION__ +
-                                     SZC("constexpr auto enchantum::details::raw_type_name_func() [with _ = "),
-                                   SZC(__PRETTY_FUNCTION__) -
-                                     SZC("constexpr auto enchantum::details::raw_type_name_func() [with _ = ]"));
-#endif
-    std::array<char, 1 + s.size() - prefix> ret{};
-    auto* const                             ret_data = ret.data();
-    const auto* const                       s_data   = s.data();
-
-    for (std::size_t i = 0; i < ret.size() - 1; ++i)
-      ret_data[i] = s_data[i + prefix];
-    return ret;
-  }
-
-  template<typename T>
-  inline constexpr auto raw_type_name_func_var = raw_type_name_func<T>();
-
-  template<typename T>
-  constexpr auto type_name_func() noexcept
-  {
-    static_assert(!std::is_function_v<std::remove_pointer_t<T>> && !std::is_member_function_pointer_v<T>,
-                  "enchantum::type_name<T> does not work well with function pointers or functions or member function\n"
-                  "pointers");
-
-    constexpr auto& array = raw_type_name_func_var<T>;
-    static_assert(array[array.size() - 2] != '>', "enchantum::type_name<T> does not work well with a templated type");
-
-    constexpr auto  s     = details::extract_name_from_type_name(string_view(array.data(), array.size() - 1));
-    std::array<char, s.size() + 1> ret{};
-    for (std::size_t i = 0; i < s.size(); ++i)
-      ret[i] = s[i];
-    return ret;
-  }
-
-  template<typename T>
-  inline constexpr auto type_name_func_var = type_name_func<T>();
-
-#undef SZC
-
-} // namespace details
-
-template<typename T>
-inline constexpr auto type_name = string_view(details::type_name_func_var<T>.data(),
-                                              details::type_name_func_var<T>.size() - 1);
-
-template<typename T>
-inline constexpr auto raw_type_name = string_view(details::raw_type_name_func_var<T>.data(),
-                                                  details::raw_type_name_func_var<T>.size() - 1);
-
-} // namespace enchantum
 
 #ifdef ENCHANTUM_CONFIG_FILE
   #include ENCHANTUM_CONFIG_FILE
+#endif
+
+#if !defined(ENCHANTUM_ALIAS_OPTIONAL) && ENCHANTUM_DETAILS_CXX_STD < 201703L
+  #error "C++14 users must define ENCHANTUM_ALIAS_OPTIONAL to an optional-compatible template alias."
 #endif
 
 #ifndef ENCHANTUM_ALIAS_OPTIONAL
@@ -121,6 +127,7 @@ using ::std::optional;
 
 } // namespace enchantum
 
+
 #ifdef ENCHANTUM_CONFIG_FILE
   #include ENCHANTUM_CONFIG_FILE
 #endif
@@ -128,6 +135,7 @@ using ::std::optional;
 #ifndef ENCHANTUM_ALIAS_STRING
   #include <string>
 #endif
+
 
 namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_STRING
@@ -137,13 +145,12 @@ using ::std::string;
 #endif
 
 } // namespace enchantum
-
 #ifdef __cpp_concepts
   #include <concepts>
 #endif
 #include <limits>
-#include <string_view>
 #include <type_traits>
+#include <utility>
 
 #ifndef ENCHANTUM_ASSERT
   #include <cassert>
@@ -166,34 +173,36 @@ using ::std::string;
 
 namespace enchantum {
 
-template<typename T, bool = std::is_enum_v<T>>
-inline constexpr bool is_scoped_enum = false;
+template<typename T, bool = std::is_enum<T>::value>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_scoped_enum = false;
 
 template<typename E>
-inline constexpr bool is_scoped_enum<E, true> = !std::is_convertible_v<E, std::underlying_type_t<E>>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_scoped_enum<E, true> = !std::is_convertible<E, std::underlying_type_t<E>>::value;
 
 template<typename E>
-inline constexpr bool is_unscoped_enum = std::is_enum_v<E> && !is_scoped_enum<E>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_unscoped_enum = std::is_enum<E>::value && !is_scoped_enum<E>;
 
 template<typename E, typename = void>
-inline constexpr bool has_fixed_underlying_type = false;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_fixed_underlying_type = false;
 
 template<typename E>
-inline constexpr bool has_fixed_underlying_type<E, decltype(void(E{0}))> = std::is_enum_v<E>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_fixed_underlying_type<E, decltype(void(E{0}))> = std::is_enum<E>::value;
+
 
 #ifdef __cpp_concepts
 
 template<typename T>
-concept Enum = std::is_enum_v<T>;
+concept Enum = std::is_enum<T>::value;
 
 template<Enum E>
-inline constexpr bool is_bitflag = requires(E e) {
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag = requires(E e) {
   requires std::same_as<decltype(e & e), bool> || std::same_as<decltype(e & e), E>;
   { ~e } -> std::same_as<E>;
   { e | e } -> std::same_as<E>;
   { e &= e } -> std::same_as<E&>;
   { e |= e } -> std::same_as<E&>;
 };
+
 
 template<typename T>
 concept SignedEnum = Enum<T> && std::signed_integral<std::underlying_type_t<T>>;
@@ -202,7 +211,7 @@ template<typename T>
 concept UnsignedEnum = Enum<T> && !SignedEnum<T>;
 
 template<typename T>
-concept ScopedEnum = Enum<T> && (!std::is_convertible_v<T, std::underlying_type_t<T>>);
+concept ScopedEnum = Enum<T> && (!std::is_convertible<T, std::underlying_type_t<T>>::value);
 
 template<typename T>
 concept UnscopedEnum = Enum<T> && !ScopedEnum<T>;
@@ -218,45 +227,65 @@ concept EnumFixedUnderlying = Enum<T> && requires { T{0}; };
 
 #else
 
+
 template<typename E, typename = void>
-inline constexpr bool is_bitflag = false;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag = false;
 
 // clang-format off
 template<typename E>
-inline constexpr bool is_bitflag<E, 
-    std::void_t<
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_bitflag<E,
+    enchantum::details::void_t<
     decltype(E{} & E{}),
-    decltype(~E{}), 
-    decltype(E{} | E{}), 
-    decltype(std::declval<E&>() &= E{}), 
+    decltype(~E{}),
+    decltype(E{} | E{}),
+    decltype(std::declval<E&>() &= E{}),
     decltype(std::declval<E&>() |= E{})
-    >> =  std::is_enum_v<E>
-    &&    (std::is_same_v<decltype(E{} & E{}),bool>  || std::is_same_v<decltype(E{} & E{}), E>) 
-    &&    std::is_same_v<decltype(~E{}), E> 
-    &&    std::is_same_v<decltype(E{} | E{}), E>
-    &&    std::is_same_v<decltype(std::declval<E&>() &= E{}), E&>
-    &&    std::is_same_v<decltype(std::declval<E&>() |= E{}), E&>
+    >> =  std::is_enum<E>::value
+    &&    (std::is_same<decltype(E{} & E{}),bool>::value  || std::is_same<decltype(E{} & E{}), E>::value)
+    &&    std::is_same<decltype(~E{}), E>::value
+    &&    std::is_same<decltype(E{} | E{}), E>::value
+    &&    std::is_same<decltype(std::declval<E&>() &= E{}), E&>::value
+    &&    std::is_same<decltype(std::declval<E&>() |= E{}), E&>::value
     ;
 // clang-format on
 #endif
+
 
 namespace details {
   template<typename T, typename U>
   constexpr auto Max(T a, U b)
   {
-    return a < b ? b : a;
-  }
+    using R = typename std::common_type<T, U>::type;
+    return static_cast<R>(a) < static_cast<R>(b) ? static_cast<R>(b) : static_cast<R>(a);
+
   template<typename T, typename U>
   constexpr auto Min(T a, U b)
   {
-    return a > b ? b : a;
+    using R = typename std::common_type<T, U>::type;
+    return static_cast<R>(a) > static_cast<R>(b) ? static_cast<R>(b) : static_cast<R>(a);
   }
-#if !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
   template<typename E, auto V, typename = void>
-  inline constexpr bool is_valid_cast = false;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_valid_cast = false;
 
   template<typename E, auto V>
-  inline constexpr bool is_valid_cast<E, V, std::void_t<std::integral_constant<E, static_cast<E>(V)>>> = true;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_valid_cast<E, V, enchantum::details::void_t<std::integral_constant<E, static_cast<E>(V)>>> = true;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  constexpr auto valid_cast_range_recurse() noexcept;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range, bool IsValid>
+  struct valid_cast_range_recurse_impl;
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  struct valid_cast_range_recurse_impl<E, range, old_range, true> {
+    static constexpr auto value() noexcept { return valid_cast_range_recurse<E, range * 2, range>(); }
+  };
+
+  template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
+  struct valid_cast_range_recurse_impl<E, range, old_range, false> {
+    static constexpr auto value() noexcept { return old_range > 0 ? old_range * 2 - 1 : old_range; }
+  };
 
   template<typename E, std::underlying_type_t<E> range, decltype(range) old_range>
   constexpr auto valid_cast_range_recurse() noexcept
@@ -269,57 +298,89 @@ namespace details {
     // while clang makes it a subsituation failure which we can check for
     // using std::inegral_constant makes sure this is a constant expression situation
     // for SFINAE to occur
-    if constexpr (is_valid_cast<E, range>)
-      return valid_cast_range_recurse<E, range * 2, range>();
-    else
-      return old_range > 0 ? old_range * 2 - 1 : old_range;
+    return valid_cast_range_recurse_impl<E, range, old_range, is_valid_cast<E, range>>::value();
   }
+
   template<typename E, int max_range>
-  constexpr auto valid_cast_range() noexcept
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, 0>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    return T{0};
+  }
+
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, 1>) noexcept
   {
     using T = std::underlying_type_t<E>;
     using L = std::numeric_limits<T>;
+    return is_valid_cast<E, (L::max)()> ? L::max() : details::valid_cast_range_recurse<E, max_range, 0>();
+  }
 
-    if constexpr (max_range == 0)
-      return T{0};
-    else if constexpr (max_range > 0 && is_valid_cast<E, (L::max)()>)
-      return L::max();
-    else if constexpr (max_range < 0 && is_valid_cast<E, (L::min)()>)
-      return L::min();
-    else
-      return details::valid_cast_range_recurse<E, max_range, 0>();
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range_impl(std::integral_constant<int, -1>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+    return is_valid_cast<E, (L::min)()> ? L::min() : details::valid_cast_range_recurse<E, max_range, 0>();
+  }
+
+  template<typename E, int max_range>
+  constexpr auto valid_cast_range() noexcept
+  {
+    return details::valid_cast_range_impl<E, max_range>(std::integral_constant<int, (max_range > 0) - (max_range < 0)>{});
   }
 
 #endif
 
   template<typename E>
+  constexpr auto enum_range_of_bool(const int max_range, std::true_type)
+  {
+    return max_range > 0;
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_signed(const int max_range, std::true_type)
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+    constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
+    constexpr auto Min = has_fixed_underlying_type<E> ? (L::min)() : details::valid_cast_range<E, -1>();
+#else
+    constexpr auto Max = (L::max)();
+    constexpr auto Min = (L::min)();
+#endif
+    return max_range > 0 ? details::Min(ENCHANTUM_MAX_RANGE, Max) : details::Max(ENCHANTUM_MIN_RANGE, Min);
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_signed(const int max_range, std::false_type)
+  {
+    using T = std::underlying_type_t<E>;
+    using L = std::numeric_limits<T>;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L && !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
+    constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
+#else
+    constexpr auto Max = (L::max)();
+#endif
+    return max_range > 0 ? details::Min(static_cast<unsigned int>(ENCHANTUM_MAX_RANGE), Max) : 0;
+  }
+
+  template<typename E>
+  constexpr auto enum_range_of_bool(const int max_range, std::false_type)
+  {
+    using T = std::underlying_type_t<E>;
+    return enum_range_of_signed<E>(max_range, std::integral_constant<bool, std::is_signed<T>::value>{});
+  }
+
+  template<typename E>
   constexpr auto enum_range_of(const int max_range)
   {
     using T = std::underlying_type_t<E>;
-    if constexpr (std::is_same_v<bool, T>) {
-      return max_range > 0;
-    }
-    else {
-      using L = std::numeric_limits<T>;
-#if !defined(__NVCOMPILER) && defined(__clang__) && __clang_major__ >= 20
-      constexpr auto Max = has_fixed_underlying_type<E> ? (L::max)() : details::valid_cast_range<E, 1>();
-      constexpr auto Min = has_fixed_underlying_type<E>
-        ? (L::min)()
-        : details::valid_cast_range<E, std::is_signed_v<T> ? -1 : 0>();
-#else
-      constexpr auto Max = (L::max)();
-      constexpr auto Min = (L::min)();
-#endif
-      (void)Min; // Only used in signed branch
-      if constexpr (std::is_signed_v<T>) {
-        return max_range > 0 ? details::Min(ENCHANTUM_MAX_RANGE, Max) : details::Max(ENCHANTUM_MIN_RANGE, Min);
-      }
-      else {
-        return max_range > 0 ? details::Min(static_cast<unsigned int>(ENCHANTUM_MAX_RANGE), Max) : 0;
-      }
-    }
+    return enum_range_of_bool<E>(max_range, std::is_same<bool, T>{});
   }
 } // namespace details
+
 
 template<typename E>
 struct enum_traits {
@@ -333,9 +394,9 @@ public:
 
 namespace details {
   template<typename T,typename = void>
-  inline constexpr bool has_specialized_traits = true;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_specialized_traits = true;
   template<typename T>
-  inline constexpr bool has_specialized_traits<T, typename enum_traits<T>::zxshady_enchantum_is_not_specialized_tag> = false;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_specialized_traits<T, typename enum_traits<T>::zxshady_enchantum_is_not_specialized_tag> = false;
 
 } // namespace details
 
@@ -345,9 +406,102 @@ namespace details {
   #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         Enum Name
   #define ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(Name) BitFlagEnum Name
 #else
-  #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         typename Name, std::enable_if_t<std::is_enum_v<Name>, int> = 0
+  #define ENCHANTUM_DETAILS_ENUM_CONCEPT(Name)         typename Name, std::enable_if_t<std::is_enum<Name>::value, int> = 0
   #define ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(Name) typename Name, std::enable_if_t<is_bitflag<Name>, int> = 0
 #endif
+#include <cstddef>
+
+namespace enchantum {
+
+namespace details {
+#define SZC(x) (sizeof(x) - 1)
+  constexpr string_view extract_name_from_type_name(const string_view type_name) noexcept
+  {
+    const auto n = type_name.rfind(':');
+    if (n != type_name.npos)
+      return type_name.substr(n + 1);
+    else
+      return type_name;
+  }
+
+  template<typename T>
+  constexpr auto raw_type_name_func() noexcept
+  {
+#if defined(__RESHARPER__)
+      constexpr std::size_t prefix =0;
+    constexpr auto s = string_view(__rscpp_type_name<T>());
+#elif defined(__NVCOMPILER)
+    constexpr std::size_t prefix = 0;
+    constexpr auto s = string_view(__PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::raw_type_name_func() noexcept [with T = "),
+            SZC(__PRETTY_FUNCTION__) - SZC("constexpr auto enchantum::details::raw_type_name_func() noexcept [with T = ]"));
+#elif defined(__clang__)
+    constexpr std::size_t prefix = 0;
+    constexpr auto s = string_view(__PRETTY_FUNCTION__ + SZC("auto enchantum::details::raw_type_name_func() [_ = "),
+                                   SZC(__PRETTY_FUNCTION__) - SZC("auto enchantum::details::raw_type_name_func() [_ = ]"));
+#elif defined(_MSC_VER)
+    constexpr auto s = string_view(__FUNCSIG__ + SZC("auto __cdecl enchantum::details::raw_type_name_func<"),
+                                   SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::raw_type_name_func<") -
+                                     SZC(">(void) noexcept"));
+
+    // clang-format off
+    constexpr auto prefix = std::is_enum<T>::value ? SZC("enum ") :
+        std::is_class<T>::value ?  SZC("struct ") - (s[0] == 'c') :
+        0;
+// clang-format on
+#elif defined(__GNUG__)
+    constexpr std::size_t prefix = 0;
+    constexpr auto        s      = string_view(__PRETTY_FUNCTION__ +
+                                     SZC("constexpr auto enchantum::details::raw_type_name_func() [with _ = "),
+                                   SZC(__PRETTY_FUNCTION__) -
+                                     SZC("constexpr auto enchantum::details::raw_type_name_func() [with _ = ]"));
+#endif
+    details::array<char, 1 + s.size() - prefix> ret{};
+    auto* const                             ret_data = ret.data();
+    const auto* const                       s_data   = s.data();
+
+    for (std::size_t i = 0; i < ret.size() - 1; ++i)
+      ret_data[i] = s_data[i + prefix];
+    return ret;
+  }
+
+  template<typename T>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto raw_type_name_func_var = raw_type_name_func<T>();
+
+
+  template<typename T>
+  constexpr auto type_name_func() noexcept
+  {
+    static_assert(!std::is_function<std::remove_pointer_t<T>>::value && !std::is_member_function_pointer<T>::value,
+                  "enchantum::type_name<T> does not work well with function pointers or functions or member function\n"
+                  "pointers");
+
+    constexpr auto& array = raw_type_name_func_var<T>;
+    static_assert(array[array.size() - 2] != '>', "enchantum::type_name<T> does not work well with a templated type");
+
+    constexpr auto  s     = details::extract_name_from_type_name(string_view(array.data(), array.size() - 1));
+    details::array<char, s.size() + 1> ret{};
+    for (std::size_t i = 0; i < s.size(); ++i)
+      ret[i] = s[i];
+    return ret;
+  }
+
+  template<typename T>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto type_name_func_var = type_name_func<T>();
+
+#undef SZC
+
+} // namespace details
+
+template<typename T>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto type_name = string_view(details::type_name_func_var<T>.data(),
+                                                                    details::type_name_func_var<T>.size() - 1);
+
+template<typename T>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto raw_type_name = string_view(details::raw_type_name_func_var<T>.data(),
+                                                                        details::raw_type_name_func_var<T>.size() - 1);
+
+
+} // namespace enchantum
 #include <array>
 #include <climits>
 #include <cstddef>
@@ -357,11 +511,12 @@ namespace details {
 namespace enchantum {
 namespace details {
 
+
   template<typename E, typename = void>
-  inline constexpr std::size_t prefix_length_or_zero = 0;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr std::size_t prefix_length_or_zero = 0;
 
   template<typename E>
-  inline constexpr auto prefix_length_or_zero<E, decltype((void)enum_traits<E>::prefix_length)> = std::size_t{
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto prefix_length_or_zero<E, decltype((void)enum_traits<E>::prefix_length)> = std::size_t{
     enum_traits<E>::prefix_length};
 
   template<typename Underlying, std::size_t ArraySize>
@@ -377,11 +532,104 @@ namespace details {
 
 } // namespace details
 } // namespace enchantum
+#if defined(__RESHARPER__)
 
-#if defined(__NVCOMPILER)
-  
+#include <cstdint>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
 
-#include <array>
+namespace enchantum {
+namespace details {
+
+  // WORKAROUND
+  // resharper seems to not copy values of arrays correctly in constexpr contexts.
+  // it copies the last element of the array to the WHOLE array
+  // giving the array a default value other than default-init fixes the issue
+  // as for why 'Count' is explicitly taken although it is equal to sizeof...(Is)
+  // is to workaround another bug, which seems to think sizeof...(Is) is 0
+  template<std::size_t Count, typename Value, std::size_t... Is>
+  constexpr auto rscpp_make_defaulted_array_of(const Value value, std::index_sequence<Is...>)
+  {
+    return details::array<Value, Count>{(Is, void(), value)...};
+  }
+
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    using T    = std::underlying_type_t<E>;
+    using U    = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
+    constexpr bool        IsBitFlag    = is_bitflag<E>;
+    constexpr std::size_t max_elements = sizeof...(Is) + IsBitFlag;
+
+    const char* names[max_elements]{};
+    T           values[max_elements]{};
+    std::size_t count = 0;
+
+    if (IsBitFlag) {
+      const auto* zero_name = __rscpp_enumerator_name(E(0));
+      if (zero_name) {
+        names[count]    = zero_name;
+        values[count++] = 0;
+      }
+
+      for (std::size_t i : {Is...}) {
+        const auto val  = T(U(1) << i);
+        const auto name = __rscpp_enumerator_name(E(val));
+        if (name) {
+          names[count]    = name;
+          values[count++] = val;
+        }
+      }
+    }
+    else {
+      for (std::size_t i = 0; i < max_elements; ++i) {
+        const auto val  = T(MinT(i) + Min);
+        const auto name = __rscpp_enumerator_name(E(val));
+        if (name) {
+          names[count]    = name;
+          values[count++] = val;
+        }
+      }
+    }
+
+    auto ret = ReflectStringReturnValue<T, max_elements>{};
+    for (std::size_t i = 0; i < count; ++i) {
+      const auto        str = names[i] + prefix_length_or_zero<E>;
+      const std::size_t len = __builtin_strlen(str);
+      ret.values[i]         = values[i];
+      ret.string_lengths[i] = len;
+      for (std::size_t j = 0; j < len; ++j)
+        ret.strings[ret.total_string_length + j] = str[j];
+      ret.total_string_length += len + (NullTerminated ? 1 : 0);
+    }
+    ret.valid_count = count;
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+
+    using Strings = details::array<char, elements_local.total_string_length>;
+
+    struct {
+      decltype(elements_local) elements;
+      Strings                  strings{};
+    } data = {elements_local};
+
+    const auto size = data.strings.size();
+    const auto str  = data.strings.data();
+    for (std::size_t i = 0; i < size; ++i)
+      str[i] = elements_local.strings[i];
+    return data;
+  }
+
+} // namespace details
+} // namespace enchantum
+#elif defined(__NVCOMPILER)
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -390,28 +638,38 @@ namespace details {
 namespace enchantum {
 
 namespace details {
+#define SZC(x) (sizeof(x) - 1)
+
   constexpr std::size_t find_semicolon(const char* s)
   {
     for (std::size_t i = 0; true; ++i)
       if (s[i] == ';')
         return i;
   }
+
+  constexpr const char* find_nvcc_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == ' ' && s[i + 2] == '=' && s[i + 3] == ' ' && s[i + 4] == '{')
+        return s + i + SZC("V = {");
+    }
+  }
+
   constexpr std::size_t enum_in_array_name_size(const string_view raw_type_name, const bool is_scoped_enum) noexcept
   {
     if (is_scoped_enum)
       return raw_type_name.size();
 
-    if (const auto pos = raw_type_name.rfind(':'); pos != string_view::npos)
+    const auto pos = raw_type_name.rfind(':');
+    if (pos != string_view::npos)
       return pos - 1;
     return 0;
   }
 
-#define SZC(x) (sizeof(x) - 1)
-
-  template<auto... V>
+  template<typename E, E... V>
   constexpr auto var_name() noexcept
   {
-    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() noexcept [with _ *V = (_ *)0; ");
+    return details::find_nvcc_values_pack(__PRETTY_FUNCTION__);
   }
 
   template<bool IsBitFlag, typename IntType>
@@ -430,79 +688,81 @@ namespace details {
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       // check if cast (starts with '(')
-      str += SZC("_ *V = ");
       if (str[0] == '(') {
         str += least_length_when_casting;
-        while (*str++ != ';')
+        while (*str++ != ',')
           /*intentionally empty*/;
         str += SZC(" ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = details::find_semicolon(str);
-        if constexpr (IsBitFlag)
+        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
         string_lengths[valid_count++] = static_cast<std::uint8_t>(commapos);
         __builtin_memcpy(strings + total_string_length, str, commapos);
         total_string_length += commapos + null_terminated;
-        str += commapos + SZC("; ");
+        str += commapos + SZC(", ");
       }
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
-  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
   {
-    using MinT = decltype(Min);
-    using T    = std::underlying_type_t<E>;
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
 
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
 #pragma diag_suppress implicit_return_from_non_void_function
-      const auto str = [](auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // forces NVCC to shorten the string types
-        struct _ {};
-        // using a pointer since C++17 only allows pointers to class types not the class types themselves
-        constexpr _* A{};
-        using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, T>, unsigned char, T>>;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<A, static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        else
-          return details::var_name<A, static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-      }(0);
+    const auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
 #pragma diag_default implicit_return_from_non_void_function
 
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size(raw_type_name<E>, is_scoped_enum<E>);
-      // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size(raw_type_name<E>, is_scoped_enum<E>);
+    // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
 
-      // ((anonymous namespace)::A)0
-      // (anonymous namespace)::a
-      // this is needed to determine whether the above are cast expression if 2 braces are
-      // next to eachother then it is a cast but only for anonymoused namespaced enums
+    // ((anonymous namespace)::A)0
+    // (anonymous namespace)::a
+    // this is needed to determine whether the above are cast expression if 2 braces are
+    // next to eachother then it is a cast but only for anonymoused namespaced enums
 
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-        /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<T>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+      /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<T>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
 
-      return ret;
-    }();
+    return ret;
+  }
 
-    using Strings = std::array<char, elements_local.total_string_length>;
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
@@ -515,7 +775,6 @@ namespace details {
 } // namespace details
 } // namespace enchantum
 #elif defined(__clang__)
-  
 
 // Clang <= 12 outputs "NUMBER" if casting
 // Clang > 12 outputs "(E)NUMBER".
@@ -527,7 +786,6 @@ namespace details {
   #endif
 #endif
 
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -542,19 +800,55 @@ namespace details {
     if (is_scoped_enum)
       return raw_type_name;
 
-    if (const auto pos = raw_type_name.rfind(':'); pos != string_view::npos)
+    const auto pos = raw_type_name.rfind(':');
+    if (pos != string_view::npos)
       return raw_type_name.substr(0, pos - 1);
     return string_view();
   }
 
 #define SZC(x) (sizeof(x) - 1)
 
-  template<auto... Vs>
+  constexpr const char* find_clang_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == 's' && s[i + 2] == ' ' && s[i + 3] == '=' && s[i + 4] == ' ' && s[i + 5] == '<')
+        return s + i + SZC("Vs = <");
+    }
+  }
+
+  template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
     // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
-    return __PRETTY_FUNCTION__ + SZC("auto enchantum::details::var_name() [Vs = <");
+    return details::find_clang_values_pack(__PRETTY_FUNCTION__);
   }
+
+
+  constexpr bool is_out_of_range_parse(
+    std::size_t       index_check,
+    const char*       str,
+    const std::size_t least_length_when_casting,
+    const std::size_t array_size)
+  {
+    (void)index_check;
+    for (std::size_t index = 0; index < array_size; ++index) {
+#if __clang_major__ > 12
+      // check if cast (starts with '(')
+      if (str[index_check] == '(')
+#else
+      // check if it is a number or negative sign
+      if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
+#endif
+      {
+        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+      }
+      else {
+        return true;
+      }
+    }
+    return false;
+  }
+
 
   template<bool IsBitFlag, typename IntType>
   constexpr void parse_string(
@@ -586,7 +880,7 @@ namespace details {
       else {
         str += least_length_when_value;
         const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
-        if constexpr (IsBitFlag)
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
@@ -597,62 +891,67 @@ namespace details {
       }
     }
   }
-  
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
+  {
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    using T          = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, T>::value, unsigned char, T>>;
+
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    const auto     str       = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+
+    constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
+    constexpr auto enum_in_array_len  = enum_in_array_name.size();
+    // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+
+    // ((anonymous namespace)::A)0
+    // (anonymous namespace)::a
+    // this is needed to determine whether the above are cast expression if 2 braces are
+    // next to eachother then it is a cast but only for anonymoused namespaced enums
+    constexpr std::size_t index_check = enum_in_array_name.size() != 0 && enum_in_array_name[0] == '(' ? 1 : 0;
+
+    details::parse_string<is_bitflag<E>>(
+      /*index_check=*/index_check,
+      /*str = */ str,
+#if __clang_major__ > 12
+      /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
+#else
+      /*least_length_when_casting=*/1,
+#endif
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<T>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
   constexpr auto reflect(std::index_sequence<Is...>) noexcept
   {
-    using MinT       = decltype(Min);
-    using T          = std::underlying_type_t<E>;
-    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, T>, unsigned char, T>>;
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
 
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      const auto     str       = [](auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-        {
-          return details::var_name<static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        }
-        else {
-          return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-        }
-      }(0);
-
-      constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
-      constexpr auto enum_in_array_len  = enum_in_array_name.size();
-      // Ubuntu Clang 20 complains about using local constexpr variables in a local struct
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-
-      // ((anonymous namespace)::A)0
-      // (anonymous namespace)::a
-      // this is needed to determine whether the above are cast expression if 2 braces are
-      // next to eachother then it is a cast but only for anonymoused namespaced enums
-      constexpr std::size_t index_check = enum_in_array_name.size() != 0 && enum_in_array_name[0] == '(' ? 1 : 0;
-
-      details::parse_string<is_bitflag<E>>(
-        /*index_check=*/index_check,
-        /*str = */ str,
-#if __clang_major__ > 12
-        /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
-#else
-        /*least_length_when_casting=*/1,
-#endif
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<T>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-
-      return ret;
-    }();
-
-    using Strings = std::array<char, elements_local.total_string_length>;
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
@@ -660,12 +959,35 @@ namespace details {
     } data = {elements_local};
     __builtin_memcpy(data.strings.data(), elements_local.strings, data.strings.size());
     return data;
-  } // namespace details
+  }
+
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
+  constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is);
+    const auto     str       = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+
+    constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
+    constexpr auto enum_in_array_len  = enum_in_array_name.size();
+    constexpr std::size_t index_check = enum_in_array_name.size() != 0 && enum_in_array_name[0] == '(' ? 1 : 0;
+    (void)enum_in_array_len; // not used until Clang 13
+    return details::is_out_of_range_parse(
+      /*index_check=*/index_check,
+      /*str = */ str,
+#if __clang_major__ > 12
+      /*least_length_when_casting=*/SZC("(") + enum_in_array_len + SZC(")0"),
+#else
+      /*least_length_when_casting=*/1,
+#endif
+      /*array_size = */ ArraySize);
+  }
 
 } // namespace details
 
+
 //template<Enum E>
 //constexpr std::size_t enum_count = details::enum_count<E>;
+
 
 } // namespace enchantum
 
@@ -676,16 +998,17 @@ namespace details {
 #endif
 #undef SZC
 #elif defined(__GNUC__) || defined(__GNUG__)
-  
-
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
 #include <type_traits>
 #include <utility>
 
-#define ENCAHNTUM_DETAILS_GCC_MAJOR __GNUC__
+#if defined(__has_include) && __has_include(<bits/char_traits.h>)
+  #include <bits/char_traits.h>
+#endif
+
+#define ENCHANTUM_DETAILS_GCC_MAJOR __GNUC__
 #if __GNUC__ <= 10
 // for out of bounds conversions for C style enums
   #pragma GCC diagnostic push
@@ -696,19 +1019,20 @@ namespace enchantum {
 namespace details {
 #define SZC(x) (sizeof(x) - 1)
 
+
   // this is needed since gcc transforms "{anonymous}" into "<unnamed>" for values
-  template<auto Enum>
+  template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
     // constexpr auto f() [with auto _ = (
     //constexpr auto f() [with auto _ = (Scoped)0]
     auto s  = string_view(__PRETTY_FUNCTION__ +
-                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = "),
-                         SZC(__PRETTY_FUNCTION__) -
-                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = ]"));
-    using E = decltype(Enum);
+                            SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
+                          SZC(__PRETTY_FUNCTION__) -
+                            SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
+    s.remove_prefix(s.find(';') + SZC(" E Enum = "));
     // if scoped
-    if constexpr (!std::is_convertible_v<E, std::underlying_type_t<E>>) {
+    if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;
     }
     else {
@@ -716,21 +1040,21 @@ namespace details {
         s.remove_prefix(SZC("("));
         s.remove_suffix(SZC(")0"));
       }
-      if (const auto pos = s.rfind(':'); pos != s.npos)
+      const auto pos = s.rfind(':');
+      if (pos != s.npos)
         return pos - 1;
       return std::size_t{0};
     }
   }
 
 #if __GNUC__ == 10
-  template<auto V>
+  template<typename E, E V>
   constexpr auto gcc10_workaround() noexcept
   {
-    using E = decltype(V);
-    using T = std::underlying_type_t<E>;
-    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with auto V = ");
+    using T               = std::underlying_type_t<E>;
+    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with E = ");
     constexpr auto begin  = __PRETTY_FUNCTION__ + prefix;
-    if constexpr (begin[0] == '(') {
+    if (begin[0] == '(') {
       std::size_t i   = SZC(__PRETTY_FUNCTION__) - prefix - SZC("(");
       const char* end = __PRETTY_FUNCTION__ + SZC(__PRETTY_FUNCTION__) - 1;
       while (*end != ')') {
@@ -740,10 +1064,11 @@ namespace details {
       --i;
       return i;
     }
-    else if constexpr (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
-      constexpr auto  s      = details::enum_in_array_name_size<E{}>();
+    else if (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
+      constexpr auto  s      = details::enum_in_array_name_size<E, E{}>();
       constexpr auto& tyname = raw_type_name<E>;
-      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+      const auto pos = tyname.rfind("::");
+      if (pos != tyname.npos) {
         return s + tyname.substr(pos).size();
       }
       else {
@@ -751,38 +1076,64 @@ namespace details {
       }
     }
     else {
-      return details::gcc10_workaround<static_cast<E>(static_cast<T>(V) + 1)>();
+      return details::gcc10_workaround<E, static_cast<E>(static_cast<T>(V) + 1)>();
     }
   }
 #endif
 
   template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting_impl(std::true_type) noexcept
+  {
+    return details::enum_in_array_name_size<Enum, Enum{}>();
+  }
+
+  template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting_impl(std::false_type) noexcept
+  {
+#if __GNUC__ == 10
+    return details::gcc10_workaround<Enum, static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
+#else
+    constexpr auto  s      = details::enum_in_array_name_size<Enum, Enum{}>();
+    constexpr auto& tyname = raw_type_name<Enum>;
+    const auto pos = tyname.rfind("::");
+    if (pos != tyname.npos)
+      return s + tyname.substr(pos).size();
+    return s + tyname.size();
+#endif
+  }
+
+  template<typename Enum>
   constexpr auto length_of_enum_in_template_array_if_casting() noexcept
   {
-    if constexpr (is_scoped_enum<Enum>) {
-      return details::enum_in_array_name_size<Enum{}>();
-    }
-    else {
-#if __GNUC__ == 10
-      return details::gcc10_workaround<static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
-#else
-      constexpr auto  s      = details::enum_in_array_name_size<Enum{}>();
-      constexpr auto& tyname = raw_type_name<Enum>;
-      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
-        return s + tyname.substr(pos).size();
-      }
-      else {
-        return s + tyname.size();
-      }
-#endif
+    return details::length_of_enum_in_template_array_if_casting_impl<Enum>(std::integral_constant<bool, is_scoped_enum<Enum>>{});
+  }
+
+  constexpr const char* find_gcc_values_pack(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i) {
+      if (s[i] == 'V' && s[i + 1] == 's' && s[i + 2] == ' ' && s[i + 3] == '=' && s[i + 4] == ' ' && s[i + 5] == '{')
+        return s + i + SZC("Vs = {");
     }
   }
 
-  template<auto... Vs>
+  template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
-    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() [with auto ...Vs = {");
+    return details::find_gcc_values_pack(__PRETTY_FUNCTION__);
   }
+
+
+  constexpr bool is_out_of_range_parse(const char* str, const std::size_t least_length_when_casting, const std::size_t array_size)
+  {
+    for (std::size_t index = 0; index < array_size; ++index) {
+      if (*str == '(')
+        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+      else
+        return true;
+    }
+    return false;
+  }
+
 
   template<bool IsBitFlag, typename IntType>
   constexpr void parse_string(
@@ -808,7 +1159,7 @@ namespace details {
         // although gcc implementation of std::char_traits::find is using a for loop internally
         // copying the code of the function makes it way slower to compile, this was surprising.
         const auto commapos = static_cast<std::size_t>(std::char_traits<char>::find(str, UINT8_MAX, ',') - str);
-        if constexpr (IsBitFlag)
+        if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
           values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
@@ -821,62 +1172,101 @@ namespace details {
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
-  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
   {
-
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      using Under              = std::underlying_type_t<E>;
-      using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, Under>, unsigned char, Under>>;
-
-      constexpr auto str = [](const auto dependant) {
 #if __GNUC__ <= 10
-      // GCC 10 does not have it
   #define CAST(type, value) static_cast<type>(value)
 #else
-      // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
-        // dummy 0
-        if constexpr (sizeof(dependant) && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<E{}, CAST(E, static_cast<Under>(Underlying{1} << Is))..., 0>();
-        else
-          return details::var_name<CAST(E, static_cast<Under>(static_cast<decltype(Min)>(Is) + Min))..., 0>();
+    return details::var_name<E, E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., E{}>();
 #undef CAST
-      }(0);
+  }
 
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
-      constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+#if __GNUC__ <= 10
+  #define CAST(type, value) static_cast<type>(value)
+#else
+  #define CAST(type, value) __builtin_bit_cast(type, value)
+#endif
+    return details::var_name<E, CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., E{}>();
+#undef CAST
+  }
 
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-        /*least_length_when_casting=*/SZC("(") + length_of_enum_in_template_array_casting + SZC(")0"),
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<std::underlying_type_t<E>>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-      return ret;
-    }();
-    using Strings = std::array<char, elements_local.total_string_length>;
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    using Under              = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, Under>::value, unsigned char, Under>>;
+
+    constexpr auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+    constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
+
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+      /*least_length_when_casting=*/SZC("(") + length_of_enum_in_template_array_casting + SZC(")0"),
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<std::underlying_type_t<E>>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
       Strings                  strings{};
-    } data = {elements_local};
+    } data                  = {elements_local};
     const auto  size        = data.strings.size();
     auto* const data_string = data.strings.data();
     for (std::size_t i = 0; i < size; ++i)
       data_string[i] = elements_local.strings[i];
     return data;
   }
+
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
+  constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is);
+    using Under              = std::underlying_type_t<E>;
+
+#if __GNUC__ <= 10
+    // GCC 10 does not have it
+  #define CAST(type, value) static_cast<type>(value)
+#else
+    // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
+  #define CAST(type, value) __builtin_bit_cast(type, value)
+#endif
+    constexpr auto str = details::var_name<E, CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., E{}>();
+#undef CAST
+
+    constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
+
+    return details::is_out_of_range_parse(
+      /*str = */ str,
+      /*least_length_when_casting=*/SZC("(") + length_of_enum_in_template_array_casting + SZC(")0"),
+      /*array_size = */ ArraySize);
+  }
+
 
 } // namespace details
 
@@ -887,11 +1277,7 @@ namespace details {
 #if __GNUC__ <= 10
   #pragma GCC diagnostic pop
 #endif
-
 #elif defined(_MSC_VER)
-  
-
-#include <array>
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -909,19 +1295,35 @@ namespace details {
 #endif
 namespace enchantum {
 
+
 #define SZC(x) (sizeof(x) - 1)
 namespace details {
 
-  template<auto Enum>
+  constexpr std::size_t find_type_value_separator(const string_view s, const std::size_t start) noexcept
+  {
+    std::size_t depth = 0;
+    for (std::size_t i = start; i < s.size(); ++i) {
+      if (s[i] == '<')
+        ++depth;
+      else if (s[i] == '>')
+        --depth;
+      else if (s[i] == ',' && depth == 0)
+        return i;
+    }
+    return s.npos;
+  }
+
+  template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
     auto s = string_view{__FUNCSIG__ + SZC("auto __cdecl enchantum::details::enum_in_array_name_size<"),
                          SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::enum_in_array_name_size<>(void) noexcept")};
+    s.remove_prefix(details::find_type_value_separator(s, 0) + 1);
 
-    if constexpr (is_scoped_enum<decltype(Enum)>) {
+    if (is_scoped_enum<E>) {
       if (s[0] == '(') {
         s.remove_prefix(SZC("(enum "));
-        s.remove_suffix(SZC(")0x0"));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
         return s.size();
       }
       return s.substr(0, s.rfind(':') - 1).size();
@@ -929,19 +1331,81 @@ namespace details {
     else {
       if (s[0] == '(') {
         s.remove_prefix(SZC("(enum "));
-        s.remove_suffix(SZC(")0x0"));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
       }
-      if (const auto pos = s.rfind(':'); pos != s.npos)
+      const auto pos = s.rfind(':');
+      if (pos != s.npos)
         return pos - 1;
       return std::size_t(0);
     }
   }
 
-  template<auto... Vs>
+  template<typename E, E... Vs>
   constexpr auto __cdecl var_name() noexcept
   {
     //auto __cdecl f<class std::array<enum `anonymous namespace'::UnscopedAnon,32>{enum `anonymous-namespace'::UnscopedAnon
-    return __FUNCSIG__ + SZC("auto __cdecl enchantum::details::var_name<");
+    constexpr string_view sig{__FUNCSIG__, SZC(__FUNCSIG__)};
+    constexpr auto        pos = details::find_type_value_separator(sig, SZC("auto __cdecl enchantum::details::var_name<"));
+    return __FUNCSIG__ + pos + SZC(",");
+  }
+  template<typename IntType>
+  constexpr bool is_out_of_range_parse(const char*       str,
+                                       const bool        skip_work_if_neg,
+                                       const std::size_t least_length_when_casting,
+                                       const IntType     min,
+                                       const std::size_t array_size)
+  {
+    for (std::size_t index = 0; index < array_size; ++index) {
+#if _MSC_VER <= 1924
+      // if it starts with the number 0 (because of 0x0) then it is a value
+      // and you cannot start an enum name with a digit so this is safe
+      if (*str == '0') {
+#else
+      // if it starts with a '(' it is a cast!
+      if (*str == '(') {
+#endif
+        if (skip_work_if_neg != 0) {
+          const auto i = min + static_cast<IntType>(index);
+          str += least_length_when_casting + ((i < 0) * skip_work_if_neg);
+        }
+        else {
+          str += least_length_when_casting;
+        }
+        while (*str++ != ',')
+          /*intentionally empty*/;
+      }
+      else {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  template<typename IntType>
+  constexpr IntType parse_string_value(const std::size_t index, const IntType, std::true_type) noexcept
+  {
+    return index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
+  }
+
+  template<typename IntType>
+  constexpr IntType parse_string_value(const std::size_t index, const IntType min, std::false_type) noexcept
+  {
+    return static_cast<IntType>(min + static_cast<IntType>(index));
+  }
+
+  template<typename IntType, std::size_t SkipIfNegative>
+  constexpr const char* skip_casted_value_string(
+    const char* str, const std::size_t least_length_when_casting, const IntType min, const std::size_t index, std::integral_constant<std::size_t, SkipIfNegative>) noexcept
+  {
+    const auto i = min + static_cast<IntType>(index);
+    return str + least_length_when_casting + ((i < 0) * SkipIfNegative);
+  }
+
+  template<typename IntType>
+  constexpr const char* skip_casted_value_string(
+    const char* str, const std::size_t least_length_when_casting, const IntType, const std::size_t, std::integral_constant<std::size_t, 0>) noexcept
+  {
+    return str + least_length_when_casting;
   }
 
   template<bool IsBitFlag, typename IntType>
@@ -960,13 +1424,13 @@ namespace details {
   {
     // clang-format off
 #if ENCHANTUM_ENABLE_MSVC_SPEEDUP
-    constexpr auto skip_work_if_neg = IsBitFlag || std::is_unsigned_v<IntType> || sizeof(IntType) <= 2 ? 0 : 
+    constexpr auto skip_work_if_neg = IsBitFlag || std::is_unsigned<IntType>::value || sizeof(IntType) <= 2 ? 0 :
 // MSVC 19.31 and below don't cast int/unsigned int into `unsigned long long` (std::uint64_t)
 // While higher versions do cast them
 #if _MSC_VER <= 1931
         sizeof(IntType) == 4
 #else
-        std::is_same_v<IntType,char32_t> 
+        std::is_same<IntType,char32_t>::value
 #endif
         ? sizeof(char32_t)*2-1 : sizeof(std::uint64_t)*2-1 - (sizeof(IntType)==8); // subtract 1 more from uint64_t since I am adding it in skip_if_cast_count
 #endif
@@ -981,13 +1445,11 @@ namespace details {
       if (*str == '(') {
 #endif
 #if ENCHANTUM_ENABLE_MSVC_SPEEDUP
-        if constexpr (skip_work_if_neg != 0) {
-          const auto i = min + static_cast<IntType>(index);
-          str += least_length_when_casting + ((i < 0) * skip_work_if_neg);
-        }
-        else {
-          str += least_length_when_casting;
-        }
+        str = details::skip_casted_value_string(str,
+                                                least_length_when_casting,
+                                                min,
+                                                index,
+                                                std::integral_constant<std::size_t, skip_work_if_neg>{});
 #else
         str += least_length_when_casting;
 #endif
@@ -1000,10 +1462,8 @@ namespace details {
         // although gcc implementation of std::char_traits::find is using a for loop internally
         // copying the code of the function makes it way slower to compile, this was surprising.
 
-        if constexpr (IsBitFlag)
-          values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
-        else
-          values[valid_count] = static_cast<IntType>(min + static_cast<IntType>(index));
+
+        values[valid_count] = details::parse_string_value(index, min, std::integral_constant<bool, IsBitFlag>{});
 
         std::size_t i = 0;
         while (str[i] != ',')
@@ -1016,60 +1476,107 @@ namespace details {
     }
   }
 
-  template<typename E, bool NullTerminated, auto Min, std::size_t... Is>
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::true_type) noexcept
+  {
+    return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+  }
+
+  template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
+  constexpr const char* reflect_var_name(std::false_type) noexcept
+  {
+    return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
+  constexpr auto reflect_elements(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
+    using Under              = std::underlying_type_t<E>;
+    using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same<bool, Under>::value, unsigned char, Under>>;
+
+
+    constexpr auto str               = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
+    constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+
+    ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
+    details::parse_string<is_bitflag<E>>(
+      /*str = */ str,
+#if _MSC_VER <= 1924
+      /*least_length_when_casting=*/SZC("0x0"),
+#else
+      /*least_length_when_casting=*/SZC("(enum ") + type_name_len + SZC(")0x0") + (sizeof(E) == 8),
+#endif
+      /*least_length_when_value=*/details::prefix_length_or_zero<E> +
+        (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
+      /*min = */ static_cast<std::underlying_type_t<E>>(Min),
+      /*array_size = */ ArraySize,
+      /*null_terminated= */ NullTerminated,
+      /*enum_values= */ ret.values,
+      /*string_lengths= */ ret.string_lengths,
+      /*strings= */ ret.strings,
+      /*total_string_length*/ ret.total_string_length,
+      /*valid_count*/ ret.valid_count);
+    return ret;
+  }
+
+  template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
   constexpr auto reflect(std::index_sequence<Is...>) noexcept
   {
-    constexpr auto elements_local = []() {
-      constexpr auto ArraySize = sizeof...(Is) + is_bitflag<E>;
-      using MinT               = decltype(Min);
-      using Under              = std::underlying_type_t<E>;
-      using Underlying = std::make_unsigned_t<std::conditional_t<std::is_same_v<bool, Under>, unsigned char, Under>>;
+    constexpr auto elements_local = reflect_elements<E, NullTerminated, MinT, Min>(std::index_sequence<Is...>{});
 
-      constexpr auto str = [](const auto dependant) {
-        constexpr bool always_true = sizeof(dependant) != 0;
-        // dummy 0
-        if constexpr (always_true && is_bitflag<E>) // sizeof... to make contest dependant
-          return details::var_name<static_cast<E>(!always_true), static_cast<E>(Underlying(1) << Is)..., 0>();
-        else
-          return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., int(!always_true)>();
-      }(0);
-      constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
-      constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
-
-      ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
-      details::parse_string<is_bitflag<E>>(
-        /*str = */ str,
-#if _MSC_VER <= 1924
-        /*least_length_when_casting=*/SZC("0x0"),
-#else
-        /*least_length_when_casting=*/SZC("(enum ") + type_name_len + SZC(")0x0") + (sizeof(E) == 8),
-#endif
-        /*least_length_when_value=*/details::prefix_length_or_zero<E> +
-          (enum_in_array_len != 0 ? enum_in_array_len + SZC("::") : 0),
-        /*min = */ static_cast<std::underlying_type_t<E>>(Min),
-        /*array_size = */ ArraySize,
-        /*null_terminated= */ NullTerminated,
-        /*enum_values= */ ret.values,
-        /*string_lengths= */ ret.string_lengths,
-        /*strings= */ ret.strings,
-        /*total_string_length*/ ret.total_string_length,
-        /*valid_count*/ ret.valid_count);
-      return ret;
-    }();
-
-    using Strings = std::array<char, elements_local.total_string_length>;
+    using Strings = details::array<char, elements_local.total_string_length>;
 
     struct {
       decltype(elements_local) elements;
       Strings                  strings{};
     } data = {elements_local};
 
-    const auto  size     = data.strings.size();
+    const auto  size        = data.strings.size();
     auto* const data_string = data.strings.data();
     for (std::size_t i = 0; i < size; ++i)
       data_string[i] = elements_local.strings[i];
     return data;
   }
+
+
+  template<typename E, typename MinT, MinT Min, std::size_t... Is>
+  constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
+  {
+    constexpr auto ArraySize = sizeof...(Is);
+    using Under              = std::underlying_type_t<E>;
+
+#if ENCHANTUM_ENABLE_MSVC_SPEEDUP
+    constexpr auto skip_work_if_neg = std::is_unsigned<Under>::value || sizeof(Under) <= 2 ? 0 :
+  // MSVC 19.31 and below don't cast int/unsigned int into `unsigned long long` (std::uint64_t)
+  // While higher versions do cast them
+  #if _MSC_VER <= 1931
+      sizeof(Under) == 4
+  #else
+      std::is_same<Under, char32_t>::value
+  #endif
+      ? sizeof(char32_t) * 2 - 1
+      : sizeof(std::uint64_t) * 2 - 1 -
+        (sizeof(Under) == 8); // subtract 1 more from uint64_t since I am adding it in skip_if_cast_count
+#else
+    constexpr auto skip_work_if_neg = false;
+#endif
+    const auto str           = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+    const auto type_name_len = details::raw_type_name_func<E>().size() - 1;
+
+    return details::is_out_of_range_parse(
+      /*str = */ str,
+      skip_work_if_neg,
+#if _MSC_VER <= 1924
+      /*least_length_when_casting=*/SZC("0x0"),
+#else
+      /*least_length_when_casting=*/SZC("(enum ") + type_name_len + SZC(")0x0") + (sizeof(E) == 8),
+#endif
+      /*min = */ static_cast<std::underlying_type_t<E>>(Min),
+      /*array_size = */ ArraySize);
+  }
+
 } // namespace details
 } // namespace enchantum
 
@@ -1078,6 +1585,7 @@ namespace details {
   #error unsupported compiler please open an issue for enchantum
 #endif
 
+#include <climits>
 #include <type_traits>
 #include <utility>
 
@@ -1098,6 +1606,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   return static_cast<std::underlying_type_t<E>>(e);
 }
 #endif
+
 
 namespace details {
 
@@ -1128,30 +1637,60 @@ namespace details {
 
   template<typename E, typename StringLengthType, std::size_t Size>
   struct FinalReflectionResult {
-    std::array<E, Size> values{};
+    details::array<E, Size> values{};
     // +1 for easier iteration on on last string
-    std::array<StringLengthType, Size + 1> string_indices{};
+    details::array<StringLengthType, Size + 1> string_indices{};
   };
 
-  template<typename E, bool NullTerminated, auto Min = enum_traits<E>::min, decltype(Min) Max = enum_traits<E>::max>
-  inline constexpr auto reflection_data_impl = details::reflect<E, NullTerminated, Min>(
+  template<typename E,
+           bool NullTerminated,
+           typename T = typename std::underlying_type<E>::type,
+           T Min = static_cast<T>(enum_traits<E>::min),
+           T Max = static_cast<T>(enum_traits<E>::max)>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data_impl = details::reflect<E, NullTerminated, T, Min>(
     std::make_index_sequence<details::get_index_sequence_max(is_bitflag<E>,
-                                                             has_fixed_underlying_type<E>,
-                                                             sizeof(E),
-                                                             Min,
-                                                             Max,
-                                                             std::is_signed_v<std::underlying_type_t<E>>)>{});
+                                                              has_fixed_underlying_type<E>,
+                                                              sizeof(E),
+                                                              Min,
+                                                              Max,
+                                                               std::is_signed<T>::value)>{});
+
+
+  template<typename E,
+           typename T = typename std::underlying_type<E>::type,
+           T Min = static_cast<T>(enum_traits<E>::min),
+           T Max = static_cast<T>(enum_traits<E>::max)>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_a_value_in = details::is_out_of_range<E, T, Min>(
+    std::make_index_sequence<
+      details::get_index_sequence_max(false, has_fixed_underlying_type<E>, sizeof(E), Min, Max, std::is_signed<T>::value)>{});
+
 
   // Thanks https://en.cppreference.com/w/cpp/utility/intcmp.html
   template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::true_type, std::false_type) noexcept
+  {
+    return t < u;
+  }
+
+  template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::false_type, std::true_type) noexcept
+  {
+    return t < 0 || std::make_unsigned_t<T>(t) < u;
+  }
+
+  template<typename T, typename U>
+  constexpr bool cmp_less_impl(const T t, const U u, std::false_type, std::false_type) noexcept
+  {
+    return u >= 0 && t < std::make_unsigned_t<U>(u);
+  }
+
+  template<typename T, typename U>
   constexpr bool cmp_less(const T t, const U u) noexcept
   {
-    if constexpr (std::is_signed_v<T> == std::is_signed_v<U>)
-      return t < u;
-    else if constexpr (std::is_signed_v<T>)
-      return t < 0 || std::make_unsigned_t<T>(t) < u;
-    else
-      return u >= 0 && t < std::make_unsigned_t<U>(u);
+    return details::cmp_less_impl(t,
+                                  u,
+                                  std::integral_constant<bool, std::is_signed<T>::value == std::is_signed<U>::value>{},
+                                  std::integral_constant<bool, std::is_signed<T>::value>{});
   }
 
   template<typename U>
@@ -1166,10 +1705,7 @@ namespace details {
     return details::cmp_less(t, int(u));
   }
 
-  constexpr bool cmp_less(const bool t, const bool u) noexcept
-  {
-    return int(t) < int(u);
-  }
+  constexpr bool cmp_less(const bool t, const bool u) noexcept { return int(t) < int(u); }
 
   template<typename T, typename U>
   constexpr T ClampToRange(U u)
@@ -1181,24 +1717,111 @@ namespace details {
       return (L::min)();
     return T(u);
   }
+
+  template<typename E, bool NullTerminated, typename T, T Min, T ScaleMin, bool MinIsNegative>
+  struct lower_out_of_bounds_checker {
+    static constexpr void check() noexcept
+    {
+      static_assert(!has_a_value_in<E, T, ScaleMin, Min - 1>,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min, T ScaleMin>
+  struct lower_out_of_bounds_checker<E, NullTerminated, T, Min, ScaleMin, false> {
+    static constexpr void check() noexcept
+    {
+      static_assert(!has_a_value_in<E, T, Min + 1, ScaleMin>,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min, bool CanCheckLower>
+  struct maybe_lower_out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Min>
+  struct maybe_lower_out_of_bounds_checker<E, NullTerminated, T, Min, true> {
+    static constexpr void check() noexcept
+    {
+      constexpr auto scale = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      lower_out_of_bounds_checker<E, NullTerminated, T, Min, Min * scale, (Min < 0)>::check();
+    }
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Max, bool CanCheckUpper>
+  struct upper_out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, typename T, T Max>
+  struct upper_out_of_bounds_checker<E, NullTerminated, T, Max, true> {
+    static constexpr void check() noexcept
+    {
+      constexpr auto scale           = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      constexpr bool upper_has_value = has_a_value_in<E, T, Max + 1, Max * scale>;
+      static_assert(!upper_has_value,
+                    "enchantum has detected that this enum is not fully reflected. Please look at "
+                    "https://github.com/ZXShady/enchantum/blob/main/docs/"
+                    "features.md#enchantum_check_out_of_bounds_by "
+                    "for more information");
+      constexpr auto min             = static_cast<T>(enum_traits<E>::min);
+      constexpr auto tmin            = std::numeric_limits<T>::min();
+      constexpr bool can_check_lower = !upper_has_value && min > tmin && min >= tmin / scale;
+      maybe_lower_out_of_bounds_checker<E, NullTerminated, T, min, can_check_lower>::check();
+    }
+  };
+
+  template<typename E, bool NullTerminated, std::size_t ValidCount, bool ShouldCheck>
+  struct out_of_bounds_checker {
+    static constexpr void check() noexcept {}
+  };
+
+  template<typename E, bool NullTerminated, std::size_t ValidCount>
+  struct out_of_bounds_checker<E, NullTerminated, ValidCount, true> {
+    static constexpr void check() noexcept
+    {
+#if defined(__NVCOMPILER) || defined(__RESHARPER__)
+      static_assert(ValidCount == reflection_data_impl<E, NullTerminated, typename std::underlying_type<E>::type,
+        details::ClampToRange<typename std::underlying_type<E>::type>(enum_traits<E>::min * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY),
+        details::ClampToRange<typename std::underlying_type<E>::type>(enum_traits<E>::max * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY)
+      >.elements.valid_count,
+          "enchantum has detected that this enum is not fully reflected. Please look at "
+          "https://github.com/ZXShady/enchantum/blob/main/docs/"
+          "features.md#enchantum_check_out_of_bounds_by "
+          "for more information");
+#else
+      using T                        = std::underlying_type_t<E>;
+      constexpr auto max             = static_cast<T>(enum_traits<E>::max);
+      constexpr auto scale           = ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY;
+      constexpr auto tmax            = std::numeric_limits<T>::max();
+      constexpr bool can_check_upper = max < tmax && max <= tmax / scale;
+      upper_out_of_bounds_checker<E, NullTerminated, T, max, can_check_upper>::check();
+#endif
+    }
+  };
+
   template<typename E, bool NullTerminated>
   constexpr auto get_reflection_data() noexcept
   {
     constexpr auto elements = reflection_data_impl<E, NullTerminated>.elements;
     using StringLengthType = std::conditional_t<(elements.total_string_length < UINT8_MAX), std::uint8_t, std::uint16_t>;
-
 #if ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY >= 2
-    if constexpr (
-  #if __clang_major__ >= 20
-      has_fixed_underlying_type<E> &&
-  #endif
-      !details::has_specialized_traits<E>) {
-      static_assert(elements.valid_count == reflection_data_impl<E, NullTerminated,
-        details::ClampToRange<std::underlying_type_t<E>>(enum_traits<E>::min * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY),
-        details::ClampToRange<std::underlying_type_t<E>>(enum_traits<E>::max * ENCHANTUM_CHECK_OUT_OF_BOUNDS_BY)
-    >.elements.valid_count,
-          "enchantum has detected that this enum is not fully reflected. Please look at https://github.com/ZXShady/enchantum/blob/main/docs/features.md#enchantum_check_out_of_bounds_by for more information");
-    }
+    details::out_of_bounds_checker<E,
+                                   NullTerminated,
+                                   elements.valid_count,
+#if __clang_major__ >= 20
+                                   has_fixed_underlying_type<E> &&
+#endif
+                                     !details::has_specialized_traits<E> && !is_bitflag<E> &&
+                                     !std::is_same<std::underlying_type_t<E>, bool>::value>::check();
 #endif
     FinalReflectionResult<E, StringLengthType, elements.valid_count> ret;
     std::size_t                                                      i            = 0;
@@ -1208,14 +1831,14 @@ namespace details {
       // "aabc"
 
       ret.string_indices[i] = string_index;
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
-  // false positives from T += T
-  // it does not make sense.
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
+      // false positives from T += T
+      // it does not make sense.
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wconversion"
 #endif
       string_index += static_cast<StringLengthType>(elements.string_lengths[i] + NullTerminated);
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic pop
 #endif
     }
@@ -1223,58 +1846,98 @@ namespace details {
     return ret;
   }
 
-  template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_data_string_storage = details::reflection_data_impl<E, NullTerminated>.strings;
 
   template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_data = details::get_reflection_data<E, NullTerminated>();
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data_string_storage = details::reflection_data_impl<E, NullTerminated>.strings;
 
   template<typename E, bool NullTerminated>
-  inline constexpr auto reflection_string_indices = reflection_data<E, NullTerminated>.string_indices;
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_data = details::get_reflection_data<E, NullTerminated>();
+
+  template<typename E, bool NullTerminated>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto reflection_string_indices = reflection_data<E, NullTerminated>.string_indices;
+
+  template<typename Pair, typename = void>
+  struct has_first_second : std::false_type {
+  };
+
+  template<typename Pair>
+  struct has_first_second<Pair, void_t<decltype(std::declval<Pair&>().first), decltype(std::declval<Pair&>().second)>>
+    : std::true_type {
+  };
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry_impl(Pair& entry, E value, const char* string, std::size_t size, std::true_type)
+  {
+    using StringView = typename std::remove_cv<typename std::remove_reference<decltype(entry.second)>::type>::type;
+    entry.first      = value;
+    entry.second     = StringView(string, size);
+  }
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry_impl(Pair& entry, E value, const char* string, std::size_t size, std::false_type)
+  {
+    entry = Pair{value, string_view(string, size)};
+  }
+
+  template<typename Pair, typename E>
+  constexpr void assign_entry(Pair& entry, E value, const char* string, std::size_t size)
+  {
+    assign_entry_impl(entry, value, string, size, has_first_second<Pair>{});
+  }
+
+  template<typename E, typename Pair, bool NullTerminated, typename Reflected = int>
+  constexpr auto get_entries()
+  {
+#if defined(__NVCOMPILER)
+    // nvc++ had issues with that and did not allow it. it just did not work after testing in godbolt and I don't know why
+    const auto reflected = details::reflection_data<E, NullTerminated>;
+    const auto strings   = details::reflection_data_string_storage<E, NullTerminated>.data();
+#else
+    constexpr auto reflected = details::reflection_data<std::remove_cv_t<E>, NullTerminated>;
+    constexpr auto strings   = details::reflection_data_string_storage<std::remove_cv_t<E>, NullTerminated>.data();
+#endif
+    constexpr auto size = reflected.values.size();
+    static_assert(size != 0,
+                  "enchantum failed to reflect this enum.\n"
+                  "Please read https://github.com/ZXShady/enchantum/blob/main/docs/limitations.md before opening an "
+                  "issue\n"
+                  "with your enum type with all its namespace/classes it is defined inside to help the creator debug "
+                  "the "
+                  "issues.");
+
+    const auto& indices = reflected.string_indices;
+#if defined(__RESHARPER__)
+    auto ret = details::rscpp_make_defaulted_array_of<size>(Pair{reflected.values[0],
+                                                                 string_view(strings + indices[0],
+                                                                             indices[1] - indices[0] - NullTerminated)},
+                                                            std::make_index_sequence<size>{});
+#else
+    details::array<Pair, size> ret{};
+#endif
+    auto* const ret_data = ret.data();
+    for (std::size_t i = 0; i < size; ++i) {
+      assign_entry(ret_data[i], reflected.values[i], strings + indices[i], indices[i + 1] - indices[i] - NullTerminated);
+    }
+    return ret;
+  }
 } // namespace details
 
 #ifdef __cpp_concepts
-template<Enum E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true>
+template<Enum E, typename Pair = std::pair<E, enchantum::string_view>, bool NullTerminated = true>
 #else
-template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+template<typename E,
+         typename Pair                            = std::pair<E, enchantum::string_view>,
+         bool NullTerminated                      = true,
+          std::enable_if_t<std::is_enum<E>::value, int> = 0>
 #endif
-inline constexpr auto entries = []() {
-
-#if defined(__NVCOMPILER)
-  // nvc++ had issues with that and did not allow it. it just did not work after testing in godbolt and I don't know why
-  const auto reflected = details::reflection_data<E, NullTerminated>;
-  const auto strings   = details::reflection_data_string_storage<E, NullTerminated>.data();
-#else
-  const auto reflected = details::reflection_data<std::remove_cv_t<E>, NullTerminated>;
-  const auto strings   = details::reflection_data_string_storage<std::remove_cv_t<E>, NullTerminated>.data();
-#endif
-  using Pairs = std::array<Pair, sizeof(reflected.values) / sizeof(reflected.values[0])>;
-  Pairs          ret{};
-  constexpr auto size = ret.size();
-  static_assert(size != 0,
-                "enchantum failed to reflect this enum.\n"
-                "Please read https://github.com/ZXShady/enchantum/blob/main/docs/limitations.md before opening an "
-                "issue\n"
-                "with your enum type with all its namespace/classes it is defined inside to help the creator debug the "
-                "issues.");
-  auto* const ret_data = ret.data();
-
-  for (std::size_t i = 0; i < size; ++i) {
-    auto& [e, s]     = ret_data[i];
-    e                = reflected.values[i];
-    using StringView = std::remove_cv_t<std::remove_reference_t<decltype(s)>>;
-    s                = StringView(strings + reflected.string_indices[i],
-                   reflected.string_indices[i + 1] - reflected.string_indices[i] - NullTerminated);
-  }
-  return ret;
-}();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto entries = enchantum::details::get_entries<E, Pair, NullTerminated>();
 
 namespace details {
   template<typename E>
   constexpr auto get_values() noexcept
   {
     constexpr auto              enums = entries<E>;
-    std::array<E, enums.size()> ret{};
+    details::array<E, enums.size()> ret{};
     const auto* const           enums_data = enums.data();
     for (std::size_t i = 0; i < ret.size(); ++i)
       ret[i] = enums_data[i].first;
@@ -1285,7 +1948,7 @@ namespace details {
   constexpr auto get_names() noexcept
   {
     constexpr auto                   enums = entries<E, std::pair<E, String>, NullTerminated>;
-    std::array<String, enums.size()> ret{};
+    details::array<String, enums.size()> ret{};
     const auto* const                enums_data = enums.data();
     for (std::size_t i = 0; i < ret.size(); ++i)
       ret[i] = enums_data[i].second;
@@ -1295,54 +1958,90 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto values = details::get_values<E>();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto values = details::get_values<E>();
 
 #ifdef __cpp_concepts
 template<Enum E, typename String = string_view, bool NullTerminated = true>
 #else
-template<typename E, typename String = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+template<typename E, typename String = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
 #endif
-inline constexpr auto names = details::get_names<E, String, NullTerminated>();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto names = details::get_names<E, String, NullTerminated>();
+
+
+#define ENCHANTUM_DECLARE_EMPTY(ENUM)                                                                                         \
+  template<>                                                                                                                  \
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr auto enchantum::entries<ENUM> = ::enchantum::details::array<std::pair<ENUM, ::enchantum::string_view>, 0> \
+  {                                                                                                                           \
+  }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto min = entries<E>.front().first;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto min = entries<E>.front().first;
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr auto max = entries<E>.back().first;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr auto max = entries<E>.back().first;
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr std::size_t count = entries<E>.size();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr std::size_t count = entries<E>.size();
+
+namespace details {
+  template<typename E, bool IsBitflag>
+  struct has_zero_flag_impl {
+    static constexpr bool value() noexcept { return false; }
+  };
+
+  template<typename E>
+  struct has_zero_flag_impl<E, true> {
+    static constexpr bool value() noexcept
+    {
+      for (const auto v : values<E>)
+        if (static_cast<typename std::underlying_type<E>::type>(v) == 0)
+          return true;
+      return false;
+    }
+  };
+
+  template<typename E, bool IsBitflag>
+  struct is_contiguous_bitflag_impl {
+    static constexpr bool value() noexcept { return false; }
+  };
+
+  template<typename E>
+  struct is_contiguous_bitflag_impl<E, true> {
+    static constexpr bool value() noexcept
+    {
+      constexpr auto& enums = entries<E>;
+      using T               = typename std::underlying_type<E>::type;
+      std::size_t i = static_cast<std::size_t>(has_zero_flag_impl<E, true>::value());
+      for (; i < enums.size() - 1; ++i)
+        if (T(enums[i].first) << 1 != T(enums[i + 1].first))
+          return false;
+      return true;
+    }
+  };
+
+  template<typename E, bool Empty>
+  struct is_contiguous_impl {
+    static constexpr bool value() noexcept
+    {
+      return static_cast<std::size_t>(enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) + 1 == count<E>;
+    }
+  };
+
+  template<typename E>
+  struct is_contiguous_impl<E, true> {
+    static constexpr bool value() noexcept { return false; }
+  };
+} // namespace details
 
 template<typename E>
-inline constexpr bool has_zero_flag = [](const auto is_bitflag) {
-  if constexpr (is_bitflag.value) {
-    for (const auto v : values<E>)
-      if (static_cast<std::underlying_type_t<E>>(v) == 0)
-        return true;
-  }
-  return false;
-}(std::bool_constant<is_bitflag<E>>{});
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = details::has_zero_flag_impl<E, is_bitflag<E>>::value();
 
 template<typename E>
-inline constexpr bool is_contiguous = static_cast<std::size_t>(
-                                        enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) +
-    1 ==
-  count<E>;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = details::is_contiguous_impl<E, count<E> == 0>::value();
+
 
 template<typename E>
-inline constexpr bool is_contiguous_bitflag = [](const auto is_bitflag) {
-  if constexpr (is_bitflag.value) {
-    constexpr auto& enums = entries<E>;
-    using T               = std::underlying_type_t<E>;
-    for (auto i = std::size_t{has_zero_flag<E>}; i < enums.size() - 1; ++i)
-      if (T(enums[i].first) << 1 != T(enums[i + 1].first))
-        return false;
-    return true;
-  }
-  else {
-    return false;
-  }
-}(std::bool_constant<is_bitflag<E>>{});
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = details::is_contiguous_bitflag_impl<E, is_bitflag<E>>::value();
 
 #ifdef __cpp_concepts
 template<typename E>
@@ -1352,10 +2051,6 @@ concept ContiguousBitFlagEnum = BitFlagEnum<E> && is_contiguous_bitflag<E>;
 #endif
 
 } // namespace enchantum
-
-#ifdef __cpp_impl_three_way_comparison
-  #include <compare>
-#endif
 
 #if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && __has_include(<bit>)
 #include <bit>
@@ -1384,10 +2079,14 @@ namespace enchantum{
   }
 }
 #endif
+#ifdef __cpp_impl_three_way_comparison
+  #include <compare>
+#endif
 #include <cstddef>
 #include <cstdint>
 #include <utility>
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   // false positives from T += T
   // it does not make sense.
   #pragma GCC diagnostic push
@@ -1398,6 +2097,7 @@ namespace enchantum {
 namespace details {
 
   struct senitiel {};
+
 
   template<typename CRTP, std::ptrdiff_t Size>
   struct sized_iterator {
@@ -1486,10 +2186,12 @@ namespace details {
       return Size == it.index;
     }
 
+
     [[nodiscard]] friend constexpr bool operator!=(senitiel, const sized_iterator it) noexcept
     {
       return Size != it.index;
     }
+
 
     [[nodiscard]] constexpr bool operator<(const sized_iterator that) const noexcept { return index < that.index; };
     [[nodiscard]] constexpr bool operator>(const sized_iterator that) const noexcept { return index > that.index; };
@@ -1552,25 +2254,31 @@ namespace details {
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using value_type = E;
+      [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
+      {
+        using T = typename std::underlying_type<E>::type;
+        return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
+      }
+
+      [[nodiscard]] constexpr E dereference(std::false_type, std::true_type) const noexcept
+      {
+        using T                        = typename std::underlying_type<E>::type;
+        using UT                       = typename std::make_unsigned<T>::type;
+        constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
+        if (has_zero_flag<E> ? this->index == 0 : false)
+          return E{};
+        return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
+      }
+
+      [[nodiscard]] constexpr E dereference(std::false_type, std::false_type) const noexcept
+      {
+        return values<E>[static_cast<std::size_t>(this->index)];
+      }
+
       [[nodiscard]] constexpr E operator*() const noexcept
       {
-        using T = std::underlying_type_t<E>;
-
-        if constexpr (is_contiguous<E>) {
-          return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
-        }
-        else if constexpr (is_contiguous_bitflag<E>) {
-          using UT                       = std::make_unsigned_t<T>;
-          constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
-
-          if constexpr (has_zero_flag<E>)
-            if (this->index == 0)
-              return E{};
-          return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
-        }
-        else {
-          return values<E>[static_cast<std::size_t>(this->index)];
-        }
+        return dereference(std::integral_constant<bool, is_contiguous<E>>{},
+                           std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
       [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
     };
@@ -1612,62 +2320,77 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::values_generator_t<E> values_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::values_generator_t<E> values_generator{};
 
 #ifdef __cpp_concepts
 template<Enum E, typename StringView = string_view, bool NullTerminated = true>
-inline constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
 
 template<Enum E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true>
-inline constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
 
 #else
-template<typename E, typename StringView = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
-inline constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
+template<typename E, typename StringView = string_view, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::names_generator_t<E, StringView, NullTerminated> names_generator{};
 
-template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true, std::enable_if_t<std::is_enum_v<E>, int> = 0>
-inline constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
+template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true, std::enable_if_t<std::is_enum<E>::value, int> = 0>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::entries_generator_t<E, Pair, NullTerminated> entries_generator{};
 
 #endif
 
 } // namespace enchantum
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic pop
 #endif
+
+// IWYU pragma: begin_exports
+// IWYU pragma: end_exports
 
 #include <type_traits>
 #include <utility>
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wconversion"
   #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
+
 namespace enchantum {
 
 namespace details {
   template<typename BinaryPredicate>
+  constexpr bool call_predicate_impl(const BinaryPredicate binary_pred, const string_view a, const string_view b, std::true_type)
+  {
+    const auto a_size = a.size();
+    if (a_size != b.size())
+      return false;
+    const auto a_data = a.data();
+    const auto b_data = b.data();
+
+    for (std::size_t i = 0; i < a_size; ++i)
+      if (!binary_pred(a_data[i], b_data[i]))
+        return false;
+    return true;
+  }
+
+  template<typename BinaryPredicate>
+  constexpr bool call_predicate_impl(const BinaryPredicate binary_pred, const string_view a, const string_view b, std::false_type)
+  {
+    static_assert(enchantum::details::is_invocable<const BinaryPredicate&, const string_view&, const string_view&>::value,
+                  "BinaryPredicate must be callable with either two chars or two string_views");
+    return binary_pred(a, b);
+  }
+
+  template<typename BinaryPredicate>
   constexpr bool call_predicate(const BinaryPredicate binary_pred, const string_view a, const string_view b)
   {
-    if constexpr (std::is_invocable_v<const BinaryPredicate&, const char&, const char&>) {
-      const auto a_size = a.size();
-      if (a_size != b.size())
-        return false;
-      const auto a_data = a.data();
-      const auto b_data = b.data();
-
-      for (std::size_t i = 0; i < a_size; ++i)
-        if (!binary_pred(a_data[i],b_data[i]))
-          return false;
-      return true;
-    }
-    else {
-      static_assert(std::is_invocable_v<const BinaryPredicate&, const string_view&, const string_view&>,
-                    "BinaryPredicate must be callable with atleast 2 char or 2 string_views");
-      return binary_pred(a, b);
-    }
+    return call_predicate_impl(binary_pred,
+                               a,
+                               b,
+                               enchantum::details::bool_constant<
+                                 enchantum::details::is_invocable<const BinaryPredicate&, const char&, const char&>::value>{});
   }
 
   constexpr std::pair<std::size_t, std::size_t> minmax_string_size(const string_view* begin, const string_view* const end)
@@ -1685,32 +2408,100 @@ namespace details {
 
 } // namespace details
 
-template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
-{
-  using T = std::underlying_type_t<E>;
 
-  if (value < T(min<E>) || value > T(max<E>))
-    return false;
+namespace details {
+  template<typename E, bool Empty>
+  struct contains_bounds {
+    static constexpr bool outside(typename std::underlying_type<E>::type value) noexcept
+    {
+      using T = typename std::underlying_type<E>::type;
+      return value < T(min<E>) || value > T(max<E>);
+    }
+  };
 
-  if constexpr (is_contiguous_bitflag<E>) {
-    if constexpr (has_zero_flag<E>)
-      if (value == 0)
-        return true;
-    const auto u = static_cast<std::make_unsigned_t<T>>(value);
+  template<typename E>
+  struct contains_bounds<E, true> {
+    static constexpr bool outside(typename std::underlying_type<E>::type) noexcept { return false; }
+  };
 
-    // std::has_single_bit
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::true_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (has_zero_flag<E> ? value == 0 : false)
+      return true;
+    const auto u = static_cast<typename std::make_unsigned<T>::type>(value);
     return u != 0 && (u & (u - 1)) == 0;
   }
-  else if constexpr (is_contiguous<E>) {
+
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type, std::false_type, std::true_type) noexcept
+  {
     return true;
   }
-  else {
+
+  template<typename E>
+  constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::false_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
     for (const auto v : values_generator<E>)
       if (static_cast<T>(v) == value)
         return true;
     return false;
   }
+
+  template<typename E>
+  constexpr bool contains_value(typename std::underlying_type<E>::type value) noexcept
+  {
+    if (details::contains_bounds<E, count<E> == 0>::outside(value))
+      return false;
+
+    return details::contains_impl<E>(value,
+                                     std::integral_constant<bool, is_contiguous_bitflag<E>>{},
+                                     std::integral_constant<bool, is_contiguous<E>>{});
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::true_type, std::false_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (details::contains_value<E>(static_cast<T>(e)))
+      return optional<std::size_t>(std::size_t(T(e) - T(min<E>)));
+    return optional<std::size_t>();
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::false_type, std::true_type) noexcept
+  {
+    using T = typename std::underlying_type<E>::type;
+    if (!details::contains_value<E>(static_cast<T>(e)))
+      return optional<std::size_t>();
+
+    const bool has_zero = has_zero_flag<E>;
+    if (has_zero ? static_cast<T>(e) == 0 : false)
+      return optional<std::size_t>(0); // assumes 0 is the index of value `0`
+
+    using U = typename std::make_unsigned<T>::type;
+    return optional<std::size_t>(std::size_t(has_zero) + details::countr_zero(static_cast<U>(e)) -
+                                details::countr_zero(static_cast<U>(values_generator<E>[static_cast<std::size_t>(has_zero)])));
+  }
+
+  template<typename E>
+  constexpr optional<std::size_t> enum_to_index_impl(const E e, std::false_type, std::false_type) noexcept
+  {
+    for (std::size_t i = 0; i < count<E>; ++i) {
+      if (values_generator<E>[i] == e)
+        return optional<std::size_t>(i);
+    }
+    return optional<std::size_t>();
+  }
+} // namespace details
+
+
+template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
+[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
+{
+  return details::contains_value<E>(value);
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
@@ -1723,7 +2514,8 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 [[nodiscard]] constexpr bool contains(const string_view name) noexcept
 {
   constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
-  if (const auto size = name.size(); size < minmax.first || size > minmax.second)
+  const auto size = name.size();
+  if (size < minmax.first || size > minmax.second)
     return false;
 
   for (const auto s : names_generator<E>)
@@ -1731,6 +2523,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
       return true;
   return false;
 }
+
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
 [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
@@ -1740,6 +2533,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
       return true;
   return false;
 }
+
 
 namespace details {
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
@@ -1756,34 +2550,12 @@ namespace details {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
     [[nodiscard]] constexpr optional<std::size_t> operator()(const E e) const noexcept
     {
-      using T = std::underlying_type_t<E>;
-
-      if constexpr (is_contiguous<E>) {
-        if (enchantum::contains(e)) {
-          return optional<std::size_t>(std::size_t(T(e) - T(min<E>)));
-        }
-      }
-      else if constexpr (is_contiguous_bitflag<E>) {
-        if (enchantum::contains(e)) {
-          constexpr bool has_zero = has_zero_flag<E>;
-          if constexpr (has_zero)
-            if (static_cast<T>(e) == 0)
-              return optional<std::size_t>(0); // assumes 0 is the index of value `0`
-
-          using U = std::make_unsigned_t<T>;
-          return has_zero + details::countr_zero(static_cast<U>(e)) -
-            details::countr_zero(static_cast<U>(values_generator<E>[has_zero]));
-        }
-      }
-      else {
-        for (std::size_t i = 0; i < count<E>; ++i) {
-          if (values_generator<E>[i] == e)
-            return optional<std::size_t>(i);
-        }
-      }
-      return optional<std::size_t>();
+      return details::enum_to_index_impl<E>(e,
+                                            std::integral_constant<bool, is_contiguous<E> && count<E> != 0>{},
+                                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
     }
   };
+
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   struct cast_functor {
@@ -1797,7 +2569,8 @@ namespace details {
     [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
     {
       constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
-      if (const auto size = name.size(); size < minmax.first || size > minmax.second)
+      const auto size = name.size();
+      if (size < minmax.first || size > minmax.second)
         return optional<E>(); // nullopt
 
       for (std::size_t i = 0; i < count<E>; ++i) {
@@ -1824,12 +2597,13 @@ namespace details {
 } // namespace details
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::index_to_enum_functor<E> index_to_enum{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::index_to_enum_functor<E> index_to_enum{};
 
-inline constexpr details::enum_to_index_functor enum_to_index{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::enum_to_index_functor enum_to_index{};
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-inline constexpr details::cast_functor<E> cast{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::cast_functor<E> cast{};
+
 
 namespace details {
   struct to_string_functor {
@@ -1843,36 +2617,52 @@ namespace details {
   };
 
 } // namespace details
-inline constexpr details::to_string_functor to_string{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::to_string_functor to_string{};
+
 
 } // namespace enchantum
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic pop
 #endif
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#include <cstddef>
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wconversion"
   #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
+
 namespace enchantum {
 
+namespace details {
+  struct equal_to_string_view {
+    constexpr bool operator()(const string_view a, const string_view b) const noexcept { return a == b; }
+  };
+
+  template<typename E>
+  constexpr E value_ors_impl()
+  {
+    static_assert(is_bitflag<E>, "");
+    using T = std::underlying_type_t<E>;
+    T ret{};
+    for (const auto val : values_generator<E>)
+      ret |= static_cast<T>(val);
+    return static_cast<E>(ret);
+  }
+} // namespace details
+
 template<typename E>
-inline constexpr E value_ors = [] {
-  static_assert(is_bitflag<E>, "");
-  using T = std::underlying_type_t<E>;
-  T ret{};
-  for (const auto val : values_generator<E>)
-    ret |= static_cast<T>(val);
-  return static_cast<E>(ret);
-}();
+ENCHANTUM_DETAILS_INLINE_VAR constexpr E value_ors = details::value_ors_impl<E>();
+
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
 {
-  if constexpr (!has_zero_flag<E>)
+  if (!has_zero_flag<E>)
     if (value == 0)
       return false;
 
@@ -1897,6 +2687,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
   return enchantum::contains<E>(s.substr(pos), binary_pred);
 }
 
+
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
 {
@@ -1909,23 +2700,24 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
   return enchantum::contains<E>(s.substr(pos));
 }
 
+
 template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
 {
   using T = std::underlying_type_t<E>;
-  if constexpr (has_zero_flag<E>)
+  if (has_zero_flag<E>)
     if (static_cast<T>(value) == 0)
-      return String(names_generator<E>[0]);
+      return String(names_generator<E>[0].data(), names_generator<E>[0].size());
 
   String name;
   T      check_value = 0;
-  for (auto i = std::size_t{has_zero_flag<E>}; i < count<E>; ++i) {
+  for (auto i = static_cast<std::size_t>(has_zero_flag<E>); i < count<E>; ++i) {
     const auto v = static_cast<T>(values_generator<E>[i]);
     if (v == (static_cast<T>(value) & v)) {
       const auto s = names_generator<E>[i];
       if (!name.empty())
         name.append(1, sep);           // append separator if not the first value
-      name.append(s.data(), s.size()); // not using operator += since this may not be std::string_view always
+      name.append(s.data(), s.size());
       check_value |= v;
     }
   }
@@ -1956,7 +2748,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
 {
-  return enchantum::cast_bitflag<E>(s, sep, [](const auto& a, const auto& b) { return a == b; });
+  return enchantum::cast_bitflag<E>(s, sep, details::equal_to_string_view{});
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
@@ -1967,7 +2759,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 
 } // namespace enchantum
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic pop
 #endif
 
@@ -1975,29 +2767,46 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 
 namespace enchantum {
 namespace details {
+  template<typename String>
+  std::string string_to_std_string(const String& name, std::true_type)
+  {
+    return name;
+  }
+
+  template<typename String>
+  std::string string_to_std_string(const String& name, std::false_type)
+  {
+    return std::string(name.data(), name.size());
+  }
+
+  template<typename E>
+  std::string format_impl(E e, std::true_type) noexcept
+  {
+    const auto name = enchantum::to_string_bitflag(e);
+    if (!name.empty())
+      return details::string_to_std_string(name, std::integral_constant<bool, std::is_same<std::string, string>::value>{});
+    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+  }
+
+  template<typename E>
+  std::string format_impl(E e, std::false_type) noexcept
+  {
+    const auto name = enchantum::to_string(e);
+    if (!name.empty())
+      return std::string(name.data(), name.size());
+    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+  }
+
   template<typename E>
   std::string format(E e) noexcept
   {
-    if constexpr (is_bitflag<E>) {
-      if (const auto name = enchantum::to_string_bitflag(e); !name.empty()) {
-        if constexpr (std::is_same_v<std::string, string>) {
-          return name;
-        }
-        else {
-          return std::string(name.data(), name.size());
-        }
-      }
-    }
-    else {
-      if (const auto name = enchantum::to_string(e); !name.empty())
-        return std::string(name.data(), name.size());
-    }
-    return std::to_string(+enchantum::to_underlying(e)); // promote using + to select int overload if to underlying returns char
+    return format_impl(e, std::integral_constant<bool, is_bitflag<E>>{});
   }
 } // namespace details
 } // namespace enchantum
 
 #include <utility>
+#include <cstddef>
 
 namespace enchantum {
 
@@ -2039,7 +2848,7 @@ namespace details {
 #if 0
 template<Enum E, std::invocable<E> Func>
 constexpr auto visit(Func func, E e) 
-noexcept(std::is_nothrow_invocable_v<Func, E>)
+noexcept(noexcept(std::declval<Func>()(std::declval<E>())))
 {
   using Ret = decltype(func(e));
   
@@ -2050,7 +2859,7 @@ noexcept(std::is_nothrow_invocable_v<Func, E>)
   }(std::make_index_sequence<count<E>>());
 }
 template<Enum... Enums, std::invocable<Enums...> Func>
-constexpr auto visit(Func func, Enums... enums) noexcept(std::is_nothrow_invocable_v<Func, Enums...>)
+constexpr auto visit(Func func, Enums... enums) noexcept(noexcept(std::declval<Func>()(std::declval<Enums>()...)))
 {
   using Ret = decltype(func(enums...));
   return [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {
@@ -2076,15 +2885,15 @@ constexpr void for_each(Func f) // intentional not const
   details::for_each<E>(f, std::make_index_sequence<count<E>>{});
 }
 } // namespace enchantum
-
 #include <array>
 #include <stdexcept>
+#include <type_traits>
 
 namespace enchantum {
 
 template<typename E, typename V, typename Container = std::array<V, count<E>>>
 class array : public Container {
-  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_enum<E>::value);
 public:
   using container_type = Container;
   using index_type     = E;
@@ -2120,11 +2929,9 @@ public:
 };
 
 } // namespace enchantum
-
 #ifndef ENCHANTUM_ALIAS_BITSET
   #include <bitset>
 #endif
-
 #include <stdexcept>
 
 namespace enchantum {
@@ -2139,7 +2946,7 @@ namespace details {
 
 template<typename E, typename Container = details::bitset<count<E>>>
 class bitset : public Container {
-  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_enum<E>::value);
 public:
 
   using container_type = Container;
@@ -2162,7 +2969,7 @@ public:
         const auto s = enchantum::names_generator<E>[i];
         if (!name.empty())
           name += sep;
-        name.append(s.data(), s.size()); // not using operator += since this may not be std::string_view always
+        name.append(s.data(), s.size());
       }
     }
     return name;
@@ -2190,9 +2997,8 @@ public:
     return operator[](*enchantum::enum_to_index(index));
   }
 
-  constexpr bool test(const E pos)
+  constexpr bool test(const E pos) const
   {
-
     if (const auto i = enchantum::enum_to_index(pos))
       return test(*i);
     ENCHANTUM_THROW(std::out_of_range("enchantum::bitset::test(E pos,bool value) out of range exception"), pos);
@@ -2205,6 +3011,7 @@ public:
       return static_cast<bitset&>(set(*i, value));
     ENCHANTUM_THROW(std::out_of_range("enchantum::bitset::set(E pos,bool value) out of range exception"), pos);
   }
+
 
   constexpr bitset& reset(const E pos)
   {
@@ -2222,6 +3029,7 @@ public:
 };
 
 } // namespace enchantum
+
 
 template<typename E>
 struct std::hash<enchantum::bitset<E>> : std::hash<enchantum::details::bitset<enchantum::count<E>>> {
@@ -2321,11 +3129,197 @@ namespace bitwise_operators {
     return static_cast<Enum>(~static_cast<std::underlying_type_t<Enum>>(a));              \
   }
 
+
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wconversion"
+  #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+namespace enchantum {
+namespace scoped {
+  namespace details {
+
+
+    constexpr string_view remove_scope_or_empty(string_view string, const string_view type_name) noexcept
+    {
+      if (string.substr(0, type_name.size()) != type_name)
+        return string_view();
+      string.remove_prefix(type_name.size());
+      if (string.substr(0, 2) != string_view("::", 2))
+        return string_view();
+      string.remove_prefix(2);
+      return string;
+    }
+  } // namespace details
+
+  template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
+  [[nodiscard]] constexpr bool contains(const string_view name) noexcept
+  {
+    const auto n = details::remove_scope_or_empty(name, type_name<E>);
+    return !n.empty() && enchantum::contains<E>(n);
+  }
+
+  template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPredicate>
+  [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPredicate binary_predicate) noexcept
+  {
+    const auto n = details::remove_scope_or_empty(name, type_name<E>);
+    return !n.empty() && enchantum::contains<E>(n, binary_predicate);
+  }
+
+  namespace details {
+    template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
+    struct scoped_cast_functor {
+      [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
+      {
+        const auto n = details::remove_scope_or_empty(name, type_name<E>);
+        return n.empty() ? optional<E>() : enchantum::cast<E>(n);
+      }
+
+      template<typename BinaryPred>
+      [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
+      {
+        const auto n = details::remove_scope_or_empty(name, type_name<E>);
+        return n.empty() ? optional<E>() : enchantum::cast<E>(n, binary_predicate);
+      }
+    };
+
+    struct to_scoped_string_functor {
+      // hacky workaround about string not being a literal type.
+      template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename String = string>
+      [[nodiscard]] constexpr String operator()(const E value) const noexcept
+      {
+        String s;
+        if (const auto i = enchantum::enum_to_index(value)) {
+          const auto scope_name = type_name<E>;
+          s.append(scope_name.data(), scope_name.size());
+          s.append("::", 2);
+          const auto name = names_generator<E>[*i];
+          s.append(name.data(), name.size());
+          return s;
+        }
+        return s;
+      }
+    };
+  } // namespace details
+
+
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr details::to_scoped_string_functor to_string;
+
+  template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
+  ENCHANTUM_DETAILS_INLINE_VAR constexpr details::scoped_cast_functor<E> cast;
+
+  template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
+  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  {
+    std::size_t pos = 0;
+    for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
+      if (!enchantum::scoped::contains<E>(s.substr(pos, i - pos), binary_pred))
+        return false;
+      pos = i + 1;
+    }
+    return enchantum::scoped::contains<E>(s.substr(pos), binary_pred);
+  }
+
+  template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
+  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
+  {
+    std::size_t pos = 0;
+    for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
+      if (!enchantum::scoped::contains<E>(s.substr(pos, i - pos)))
+        return false;
+      pos = i + 1;
+    }
+    return enchantum::scoped::contains<E>(s.substr(pos));
+  }
+
+
+  template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
+  [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
+  {
+    using T = std::underlying_type_t<E>;
+    if (has_zero_flag<E>)
+      if (static_cast<T>(value) == 0)
+        return enchantum::scoped::to_string(value);
+
+    String         name;
+    T              check_value = 0;
+    constexpr auto scope_name  = type_name<E>;
+    for (auto i = static_cast<std::size_t>(has_zero_flag<E>); i < count<E>; ++i) {
+      const auto v = static_cast<T>(values_generator<E>[i]);
+      if (v == (static_cast<T>(value) & v)) {
+        if (!name.empty())
+          name.append(1, sep); // append separator if not the first value
+        name.append(scope_name.data(), scope_name.size());
+        name.append("::", 2);
+        const auto s = names_generator<E>[i];
+        name.append(s.data(), s.size());
+        check_value |= v;
+      }
+    }
+    if (check_value == static_cast<T>(value))
+      return name;
+    return string();
+  }
+
+
+  template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
+  [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  {
+    using T = std::underlying_type_t<E>;
+    T           check_value{};
+    std::size_t pos = 0;
+    for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
+      if (const auto v = enchantum::scoped::cast<E>(s.substr(pos, i - pos), binary_pred))
+        check_value |= static_cast<T>(*v);
+      else
+        return optional<E>();
+      pos = i + 1;
+    }
+
+    if (const auto v = enchantum::scoped::cast<E>(s.substr(pos), binary_pred))
+      return optional<E>(static_cast<E>(check_value | static_cast<T>(*v)));
+    return optional<E>();
+  }
+
+  template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
+[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
+{
+  return enchantum::scoped::cast_bitflag<E>(s, sep, enchantum::details::equal_to_string_view{});
+}
+} // namespace scoped
+} // namespace enchantum
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
+  #pragma GCC diagnostic pop
+#endif
+
 #include <iostream>
 #include <string>
 
 namespace enchantum {
 namespace iostream_operators {
+  template<typename E>
+  bool extract_enum_from_string(const std::string& s, E& value, std::true_type)
+  {
+    if (const auto v = enchantum::cast_bitflag<E>(s)) {
+      value = *v;
+      return true;
+    }
+    return false;
+  }
+
+  template<typename E>
+  bool extract_enum_from_string(const std::string& s, E& value, std::false_type)
+  {
+    if (const auto v = enchantum::cast<E>(s)) {
+      value = *v;
+      return true;
+    }
+    return false;
+  }
+
   template<typename Traits, ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   std::basic_ostream<char, Traits>& operator<<(std::basic_ostream<char, Traits>& os, const E e)
   {
@@ -2341,18 +3335,8 @@ namespace iostream_operators {
     if (!is)
       return is;
 
-    if constexpr (is_bitflag<E>) {
-      if (const auto v = enchantum::cast_bitflag<E>(s))
-        value = *v;
-      else
-        is.setstate(std::ios_base::failbit);
-    }
-    else {
-      if (const auto v = enchantum::cast<E>(s))
-        value = *v;
-      else
-        is.setstate(std::ios_base::failbit);
-    }
+    if (!extract_enum_from_string(s, value, std::integral_constant<bool, is_bitflag<E>>{}))
+      is.setstate(std::ios_base::failbit);
     return is;
   }
 } // namespace iostream_operators
@@ -2360,7 +3344,7 @@ namespace iostream_operators {
 
 #include <cstddef>
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
@@ -2395,19 +3379,19 @@ namespace details {
   };
 } // namespace details
 
-inline constexpr details::next_value_functor<1>           next_value{};
-inline constexpr details::next_value_functor<-1>          prev_value{};
-inline constexpr details::next_value_circular_functor<1>  next_value_circular{};
-inline constexpr details::next_value_circular_functor<-1> prev_value_circular{};
+
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_functor<1>           next_value{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_functor<-1>          prev_value{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_circular_functor<1>  next_value_circular{};
+ENCHANTUM_DETAILS_INLINE_VAR constexpr details::next_value_circular_functor<-1> prev_value_circular{};
 
 } // namespace enchantum
 
-#if defined(ENCAHNTUM_DETAILS_GCC_MAJOR) && ENCAHNTUM_DETAILS_GCC_MAJOR <= 10
+
+#if defined(ENCHANTUM_DETAILS_GCC_MAJOR) && ENCHANTUM_DETAILS_GCC_MAJOR <= 10
   #pragma GCC diagnostic pop
 #endif
-
 #if __has_include(<fmt/format.h>)
-  
 
 #include <fmt/format.h>
 
@@ -2416,7 +3400,7 @@ template<enchantum::Enum E>
 struct fmt::formatter<E>
 #else
 template<typename E>
-struct fmt::formatter<E, char, std::enable_if_t<std::is_enum_v<E>>>
+struct fmt::formatter<E, char, std::enable_if_t<std::is_enum<E>::value>>
 #endif
 : fmt::formatter<string_view> {
   template<typename FmtContext>
@@ -2426,7 +3410,6 @@ struct fmt::formatter<E, char, std::enable_if_t<std::is_enum_v<E>>>
   }
 };
 #elif (__cplusplus >= 202002 || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002)) && __has_include(<format>)
-  
 
 #include <format>
 #include <string_view>

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -1031,7 +1031,10 @@ namespace details {
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
                           SZC(__PRETTY_FUNCTION__) -
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
-    s.remove_prefix(s.find(';') + SZC("; E Enum = "));
+    std::size_t enum_pos = 0;
+    while (s[enum_pos] != ';')
+      ++enum_pos;
+    s.remove_prefix(enum_pos + SZC("; E Enum = "));
     // if scoped
     if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -1031,7 +1031,7 @@ namespace details {
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = "),
                           SZC(__PRETTY_FUNCTION__) -
                             SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with E = ]"));
-    s.remove_prefix(s.find(';') + SZC(" E Enum = "));
+    s.remove_prefix(s.find(';') + SZC("; E Enum = "));
     // if scoped
     if (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
       return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -814,6 +814,7 @@ namespace details {
 
 #define SZC(x) (sizeof(x) - 1)
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_clang_values_pack(const char* s) noexcept
   {
     for (std::size_t i = 0; true; ++i) {
@@ -828,6 +829,14 @@ namespace details {
     // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
     return details::find_clang_values_pack(__PRETTY_FUNCTION__);
   }
+#else
+  template<auto... Vs>
+  constexpr auto var_name() noexcept
+  {
+    // "auto enchantum::details::var_name() [Vs = <(A)0, a, b, c, e, d, (A)6>]"
+    return __PRETTY_FUNCTION__ + SZC("auto enchantum::details::var_name() [Vs = <");
+  }
+#endif
 
 
   constexpr bool is_out_of_range_parse(
@@ -901,13 +910,21 @@ namespace details {
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::true_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(false), static_cast<E>(Underlying(1) << Is)..., 0>();
+#else
     return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+#endif
   }
 
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::false_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
   }
 
   template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
@@ -971,7 +988,11 @@ namespace details {
   constexpr bool is_out_of_range(std::index_sequence<Is...>) noexcept
   {
     constexpr auto ArraySize = sizeof...(Is);
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    const auto     str       = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     const auto     str       = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
 
     constexpr auto enum_in_array_name = details::enum_in_array_name(raw_type_name<E>, is_scoped_enum<E>);
     constexpr auto enum_in_array_len  = enum_in_array_name.size();
@@ -1027,6 +1048,32 @@ namespace details {
 
 
   // this is needed since gcc transforms "{anonymous}" into "<unnamed>" for values
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto Enum>
+  constexpr auto enum_in_array_name_size() noexcept
+  {
+    // constexpr auto f() [with auto _ = (
+    //constexpr auto f() [with auto _ = (Scoped)0]
+    auto s  = string_view(__PRETTY_FUNCTION__ +
+                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = "),
+                         SZC(__PRETTY_FUNCTION__) -
+                           SZC("constexpr auto enchantum::details::enum_in_array_name_size() [with auto Enum = ]"));
+    using E = decltype(Enum);
+    // if scoped
+    if constexpr (!std::is_convertible<E, std::underlying_type_t<E>>::value) {
+      return s[0] == '(' ? s.size() - SZC("()0") : s.rfind(':') - 1;
+    }
+    else {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("("));
+        s.remove_suffix(SZC(")0"));
+      }
+      if (const auto pos = s.rfind(':'); pos != s.npos)
+        return pos - 1;
+      return std::size_t{0};
+    }
+  }
+#else
   template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
@@ -1055,8 +1102,42 @@ namespace details {
       return std::size_t{0};
     }
   }
+#endif
 
 #if __GNUC__ == 10
+  #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto V>
+  constexpr auto gcc10_workaround() noexcept
+  {
+    using E               = decltype(V);
+    using T               = std::underlying_type_t<E>;
+    constexpr auto prefix = SZC("constexpr auto enchantum::details::gcc10_workaround() [with auto V = ");
+    constexpr auto begin  = __PRETTY_FUNCTION__ + prefix;
+    if constexpr (begin[0] == '(') {
+      std::size_t i   = SZC(__PRETTY_FUNCTION__) - prefix - SZC("(");
+      const char* end = __PRETTY_FUNCTION__ + SZC(__PRETTY_FUNCTION__) - 1;
+      while (*end != ')') {
+        --end;
+        --i;
+      }
+      --i;
+      return i;
+    }
+    else if constexpr (static_cast<T>(V) == (std::numeric_limits<T>::max)()) {
+      constexpr auto  s      = details::enum_in_array_name_size<E{}>();
+      constexpr auto& tyname = raw_type_name<E>;
+      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+        return s + tyname.substr(pos).size();
+      }
+      else {
+        return s + tyname.size();
+      }
+    }
+    else {
+      return details::gcc10_workaround<static_cast<E>(static_cast<T>(V) + 1)>();
+    }
+  }
+  #else
   template<typename E, E V>
   constexpr auto gcc10_workaround() noexcept
   {
@@ -1088,8 +1169,32 @@ namespace details {
       return details::gcc10_workaround<E, static_cast<E>(static_cast<T>(V) + 1)>();
     }
   }
+  #endif
 #endif
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<typename Enum>
+  constexpr auto length_of_enum_in_template_array_if_casting() noexcept
+  {
+    if constexpr (is_scoped_enum<Enum>) {
+      return details::enum_in_array_name_size<Enum{}>();
+    }
+    else {
+#if __GNUC__ == 10
+      return details::gcc10_workaround<static_cast<Enum>((std::numeric_limits<std::underlying_type_t<Enum>>::min)())>();
+#else
+      constexpr auto  s      = details::enum_in_array_name_size<Enum{}>();
+      constexpr auto& tyname = raw_type_name<Enum>;
+      if (constexpr auto pos = tyname.rfind("::"); pos != tyname.npos) {
+        return s + tyname.substr(pos).size();
+      }
+      else {
+        return s + tyname.size();
+      }
+#endif
+    }
+  }
+#else
   template<typename Enum>
   constexpr auto length_of_enum_in_template_array_if_casting_impl(std::true_type) noexcept
   {
@@ -1116,7 +1221,9 @@ namespace details {
   {
     return details::length_of_enum_in_template_array_if_casting_impl<Enum>(std::integral_constant<bool, is_scoped_enum<Enum>>{});
   }
+#endif
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_gcc_values_pack(const char* s) noexcept
   {
     for (std::size_t i = 0; true; ++i) {
@@ -1139,16 +1246,30 @@ namespace details {
   {
     return details::find_gcc_values_pack(__PRETTY_FUNCTION__);
   }
+#else
+  template<auto... Vs>
+  constexpr auto var_name() noexcept
+  {
+    return __PRETTY_FUNCTION__ + SZC("constexpr auto enchantum::details::var_name() [with auto ...Vs = {");
+  }
+#endif
 
 
   constexpr bool is_out_of_range_parse(const char* str, const std::size_t least_length_when_casting, const std::size_t array_size)
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return false;
+        str = comma + SZC(", ");
+#else
         const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
         if (comma == nullptr || *comma == '\0')
           return false;
         str = comma + SZC(", ");
+#endif
       }
       else
         return true;
@@ -1174,17 +1295,31 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',');
+        if (comma == nullptr || *comma == '\0')
+          return;
+        str = comma + SZC(", ");
+#else
         const auto comma = details::find_char(str + least_length_when_casting, UINT8_MAX, ',');
         if (comma == nullptr || *comma == '\0')
           return;
         str = comma + SZC(", ");
+#endif
       }
       else {
         str += least_length_when_value;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        const auto comma = std::char_traits<char>::find(str, UINT8_MAX, ',');
+        if (comma == nullptr)
+          return;
+        const auto commapos = static_cast<std::size_t>(comma - str);
+#else
         const auto comma = details::find_char(str, UINT8_MAX, ',');
         if (comma == nullptr)
           return;
         const auto commapos = static_cast<std::size_t>(comma - str);
+#endif
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -1193,9 +1328,13 @@ namespace details {
         for (std::size_t i = 0; i < commapos; ++i)
           strings[total_string_length++] = str[i];
         total_string_length += null_terminated;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        str += commapos + SZC(", ");
+#else
         if (*comma == '\0')
           return;
         str = comma + SZC(", ");
+#endif
       }
     }
   }
@@ -1209,7 +1348,11 @@ namespace details {
 #else
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., 0>();
+#else
     return details::var_name<E, E{}, CAST(E, static_cast<typename std::underlying_type<E>::type>(Underlying{1} << Is))..., E{}>();
+#endif
 #undef CAST
   }
 
@@ -1221,7 +1364,11 @@ namespace details {
 #else
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., 0>();
+#else
     return details::var_name<E, CAST(E, static_cast<typename std::underlying_type<E>::type>(static_cast<MinT>(Is) + Min))..., E{}>();
+#endif
 #undef CAST
   }
 
@@ -1234,7 +1381,11 @@ namespace details {
 
     constexpr auto str = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
+#else
     constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+#endif
     constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
 
     ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
@@ -1284,7 +1435,11 @@ namespace details {
     // __builtin_bit_cast used to silence errors when casting out of unscoped enums range
   #define CAST(type, value) __builtin_bit_cast(type, value)
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto str = details::var_name<CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., 0>();
+#else
     constexpr auto str = details::var_name<E, CAST(E, static_cast<Under>(static_cast<MinT>(Is) + Min))..., E{}>();
+#endif
 #undef CAST
 
     constexpr auto length_of_enum_in_template_array_casting = details::length_of_enum_in_template_array_if_casting<E>();
@@ -1341,6 +1496,33 @@ namespace details {
     return s.npos;
   }
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto Enum>
+  constexpr auto enum_in_array_name_size() noexcept
+  {
+    auto s = string_view{__FUNCSIG__ + SZC("auto __cdecl enchantum::details::enum_in_array_name_size<"),
+                         SZC(__FUNCSIG__) - SZC("auto __cdecl enchantum::details::enum_in_array_name_size<>(void) noexcept")};
+    using E = decltype(Enum);
+
+    if constexpr (is_scoped_enum<E>) {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("(enum "));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
+        return s.size();
+      }
+      return s.substr(0, s.rfind(':') - 1).size();
+    }
+    else {
+      if (s[0] == '(') {
+        s.remove_prefix(SZC("(enum "));
+        s.remove_suffix(SZC(")0x0") + (sizeof(Enum) == 8)); // MSVC adds a extra 0 at the end for some reason for 8 bit enums
+      }
+      if (const auto pos = s.rfind(':'); pos != s.npos)
+        return pos - 1;
+      return std::size_t(0);
+    }
+  }
+#else
   template<typename E, E Enum>
   constexpr auto enum_in_array_name_size() noexcept
   {
@@ -1367,7 +1549,16 @@ namespace details {
       return std::size_t(0);
     }
   }
+#endif
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+  template<auto... Vs>
+  constexpr auto __cdecl var_name() noexcept
+  {
+    //auto __cdecl f<class std::array<enum `anonymous namespace'::UnscopedAnon,32>{enum `anonymous-namespace'::UnscopedAnon
+    return __FUNCSIG__ + SZC("auto __cdecl enchantum::details::var_name<");
+  }
+#else
   template<typename E, E... Vs>
   constexpr auto __cdecl var_name() noexcept
   {
@@ -1376,6 +1567,7 @@ namespace details {
     constexpr auto        pos = details::find_type_value_separator(sig, SZC("auto __cdecl enchantum::details::var_name<"));
     return __FUNCSIG__ + pos + SZC(",");
   }
+#endif
   template<typename IntType>
   constexpr bool is_out_of_range_parse(const char*       str,
                                        const bool        skip_work_if_neg,
@@ -1507,13 +1699,21 @@ namespace details {
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::true_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<E{}, static_cast<E>(Underlying(1) << Is)..., 0>();
+#else
     return details::var_name<E, E{}, static_cast<E>(Underlying(1) << Is)..., E{}>();
+#endif
   }
 
   template<typename E, typename MinT, MinT Min, typename Underlying, std::size_t... Is>
   constexpr const char* reflect_var_name(std::false_type) noexcept
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     return details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
   }
 
   template<typename E, bool NullTerminated, typename MinT, MinT Min, std::size_t... Is>
@@ -1526,7 +1726,11 @@ namespace details {
 
     constexpr auto str               = details::reflect_var_name<E, MinT, Min, Underlying, Is...>(std::integral_constant<bool, is_bitflag<E>>{});
     constexpr auto type_name_len     = details::raw_type_name_func<E>().size() - 1;
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    constexpr auto enum_in_array_len = details::enum_in_array_name_size<E{}>();
+#else
     constexpr auto enum_in_array_len = details::enum_in_array_name_size<E, E{}>();
+#endif
 
     ReflectStringReturnValue<std::underlying_type_t<E>, ArraySize> ret;
     details::parse_string<is_bitflag<E>>(
@@ -1590,7 +1794,11 @@ namespace details {
 #else
     constexpr auto skip_work_if_neg = false;
 #endif
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    const auto str           = details::var_name<static_cast<E>(static_cast<MinT>(Is) + Min)..., 0>();
+#else
     const auto str           = details::var_name<E, static_cast<E>(static_cast<MinT>(Is) + Min)..., E{}>();
+#endif
     const auto type_name_len = details::raw_type_name_func<E>().size() - 1;
 
     return details::is_out_of_range_parse(

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -49,6 +49,7 @@ struct type_identity {
   using type = T;
 };
 
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
 template<typename T, std::size_t N>
 struct cxx14_array {
   T elems[N == 0 ? 1 : N]{};
@@ -74,6 +75,7 @@ struct cxx14_array {
   constexpr std::size_t size() const noexcept { return N; }
   constexpr bool        empty() const noexcept { return N == 0; }
 };
+#endif
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
 template<typename T, std::size_t N>
@@ -2060,6 +2062,40 @@ namespace details {
   };
 } // namespace details
 
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = [](const auto is_bitflag) {
+  if constexpr (is_bitflag.value) {
+    for (const auto v : values<E>)
+      if (static_cast<std::underlying_type_t<E>>(v) == 0)
+        return true;
+  }
+  return false;
+}(std::integral_constant<bool, is_bitflag<E>>{});
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = []() {
+  if constexpr (count<E> == 0)
+    return false;
+  else
+    return static_cast<std::size_t>(enchantum::to_underlying(max<E>) - enchantum::to_underlying(min<E>)) + 1 == count<E>;
+}();
+
+template<typename E>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = [](const auto is_bitflag) {
+  if constexpr (is_bitflag.value) {
+    constexpr auto& enums = entries<E>;
+    using T               = std::underlying_type_t<E>;
+    for (auto i = std::size_t{has_zero_flag<E>}; i < enums.size() - 1; ++i)
+      if (T(enums[i].first) << 1 != T(enums[i + 1].first))
+        return false;
+    return true;
+  }
+  else {
+    return false;
+  }
+}(std::integral_constant<bool, is_bitflag<E>>{});
+#else
 template<typename E>
 ENCHANTUM_DETAILS_INLINE_VAR constexpr bool has_zero_flag = details::has_zero_flag_impl<E, is_bitflag<E>>::value();
 
@@ -2069,6 +2105,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous = details::is_contiguo
 
 template<typename E>
 ENCHANTUM_DETAILS_INLINE_VAR constexpr bool is_contiguous_bitflag = details::is_contiguous_bitflag_impl<E, is_bitflag<E>>::value();
+#endif
 
 #ifdef __cpp_concepts
 template<typename E>
@@ -2292,6 +2329,7 @@ namespace details {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
       using base::operator+=;
+#if ENCHANTUM_DETAILS_CXX_STD < 201703L
       ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
@@ -2312,11 +2350,30 @@ namespace details {
       {
         return values<E>[static_cast<std::size_t>(this->index)];
       }
+#endif
 
       ENCHANTUM_DETAILS_NODISCARD constexpr E operator*() const noexcept
       {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+        if constexpr (is_contiguous<E>) {
+          using T = typename std::underlying_type<E>::type;
+          return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
+        }
+        else if constexpr (is_contiguous_bitflag<E>) {
+          using T                        = typename std::underlying_type<E>::type;
+          using UT                       = typename std::make_unsigned<T>::type;
+          constexpr auto real_min_offset = details::countr_zero(static_cast<UT>(values<E>[has_zero_flag<E>]));
+          if (has_zero_flag<E> ? this->index == 0 : false)
+            return E{};
+          return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
+        }
+        else {
+          return values<E>[static_cast<std::size_t>(this->index)];
+        }
+#else
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
+#endif
       }
       ENCHANTUM_DETAILS_NODISCARD constexpr E operator[](const std::ptrdiff_t i) const noexcept
       {
@@ -2933,8 +2990,12 @@ namespace details {
   template<typename E, typename Func, std::size_t... I>
   constexpr void for_each(Func& f, std::index_sequence<I...>)
   {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    ((void)f(std::integral_constant<E, values<E>[I]>{}), ...);
+#else
     using expander = int[];
     (void)expander{0, ((void)f(std::integral_constant<E, values<E>[I]> {}), 0)...};
+#endif
   }
 
 } // namespace details

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -70,6 +70,7 @@ struct cxx14_array {
   constexpr const T* end() const noexcept { return elems + N; }
 
   constexpr std::size_t size() const noexcept { return N; }
+  constexpr bool        empty() const noexcept { return N == 0; }
 };
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
@@ -3017,6 +3018,8 @@ public:
 
   using Container::Container;
   using Container::operator=;
+
+  constexpr bitset() = default;
 
   [[nodiscard]] string to_string(const char sep = '|') const
   {

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -105,7 +105,7 @@ namespace enchantum {
 #ifdef ENCHANTUM_ALIAS_STRING_VIEW
 ENCHANTUM_ALIAS_STRING_VIEW;
 #else
-using ::std ::string_view;
+using ::std::string_view;
 #endif
 
 } // namespace enchantum
@@ -646,10 +646,10 @@ namespace enchantum {
 namespace details {
 #define SZC(x) (sizeof(x) - 1)
 
-  constexpr std::size_t find_semicolon(const char* s)
+  constexpr std::size_t find_comma(const char* s)
   {
     for (std::size_t i = 0; true; ++i)
-      if (s[i] == ';')
+      if (s[i] == ',')
         return i;
   }
 
@@ -702,7 +702,7 @@ namespace details {
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        const auto commapos = details::find_comma(str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -814,6 +814,13 @@ namespace details {
 
 #define SZC(x) (sizeof(x) - 1)
 
+  constexpr const char* find_comma(const char* s) noexcept
+  {
+    for (std::size_t i = 0; true; ++i)
+      if (s[i] == ',')
+        return s + i;
+  }
+
 #if ENCHANTUM_DETAILS_CXX_STD < 201703L
   constexpr const char* find_clang_values_pack(const char* s) noexcept
   {
@@ -855,7 +862,7 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = details::find_comma(str + least_length_when_casting) + SZC(", ");
       }
       else {
         return true;
@@ -890,11 +897,11 @@ namespace details {
       if (str[0] == '-' || (str[0] >= '0' && str[0] <= '9'))
 #endif
       {
-        str = __builtin_char_memchr(str + least_length_when_casting, ',', UINT8_MAX) + SZC(", ");
+        str = details::find_comma(str + least_length_when_casting) + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        const auto commapos = static_cast<std::size_t>(__builtin_char_memchr(str, ',', UINT8_MAX) - str);
+        const auto commapos = static_cast<std::size_t>(details::find_comma(str) - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -2971,7 +2978,7 @@ namespace details {
   template<typename E>
   constexpr E value_ors_impl()
   {
-    static_assert(is_bitflag<E>, "");
+    static_assert(is_bitflag<E>, "enchantum::value_ors requires a bitflag enum (is_bitflag<E> must be true)");
     using T = std::underlying_type_t<E>;
     T ret{};
     for (std::size_t i = 0; i < count<E>; ++i)

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -16,8 +16,10 @@
 
 #if ENCHANTUM_DETAILS_CXX_STD >= 201703L
   #define ENCHANTUM_DETAILS_INLINE_VAR inline
+  #define ENCHANTUM_DETAILS_NODISCARD [[nodiscard]]
 #else
   #define ENCHANTUM_DETAILS_INLINE_VAR
+  #define ENCHANTUM_DETAILS_NODISCARD
 #endif
 
 namespace enchantum {
@@ -1625,7 +1627,7 @@ namespace enchantum {
 using ::std::to_underlying;
 #else
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr auto to_underlying(const E e) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr auto to_underlying(const E e) noexcept
 {
   return static_cast<std::underlying_type_t<E>>(e);
 }
@@ -2153,94 +2155,94 @@ namespace details {
       return static_cast<CRTP&>(*this);
     }
 
-    [[nodiscard]] constexpr CRTP operator++(int) & noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr CRTP operator++(int) & noexcept
     {
       auto copy = static_cast<CRTP&>(*this);
       ++*this;
       return copy;
     }
-    [[nodiscard]] constexpr CRTP operator--(int) & noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr CRTP operator--(int) & noexcept
     {
       auto copy = static_cast<CRTP&>(*this);
       --*this;
       return copy;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator+(CRTP it, const std::ptrdiff_t offset) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator+(CRTP it, const std::ptrdiff_t offset) noexcept
     {
       it += offset;
       return it;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator+(const std::ptrdiff_t offset, CRTP it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator+(const std::ptrdiff_t offset, CRTP it) noexcept
     {
       it += offset;
       return it;
     }
 
-    [[nodiscard]] constexpr friend CRTP operator-(CRTP it, const std::ptrdiff_t offset) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr friend CRTP operator-(CRTP it, const std::ptrdiff_t offset) noexcept
     {
       it -= offset;
       return it;
     }
 
-    [[nodiscard]] constexpr std::ptrdiff_t operator-(const sized_iterator that) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr std::ptrdiff_t operator-(const sized_iterator that) const noexcept
     {
       return index - that.index;
     }
 
-    [[nodiscard]] constexpr std::ptrdiff_t        operator-(senitiel) const noexcept { return index - Size; }
-    [[nodiscard]] friend constexpr std::ptrdiff_t operator-(senitiel, sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr std::ptrdiff_t        operator-(senitiel) const noexcept { return index - Size; }
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr std::ptrdiff_t operator-(senitiel, sized_iterator it) noexcept
     {
       return Size - it.index;
     }
 
-    [[nodiscard]] constexpr bool operator==(const sized_iterator that) const noexcept { return that.index == index; };
-    [[nodiscard]] constexpr bool operator==(senitiel) const noexcept { return Size == index; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator==(const sized_iterator that) const noexcept { return that.index == index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator==(senitiel) const noexcept { return Size == index; }
 
 #ifdef __cpp_impl_three_way_comparison
-    [[nodiscard]] constexpr auto operator<=>(const sized_iterator that) const noexcept { return index <=> that.index; };
-    [[nodiscard]] constexpr auto operator<=>(senitiel) const noexcept { return index <=> Size; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator<=>(const sized_iterator that) const noexcept { return index <=> that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator<=>(senitiel) const noexcept { return index <=> Size; }
 #else
 
-    [[nodiscard]] constexpr bool operator!=(const sized_iterator that) const noexcept { return that.index != index; };
-    [[nodiscard]] constexpr bool operator!=(senitiel) const noexcept { return Size != index; }
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator!=(const sized_iterator that) const noexcept { return that.index != index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator!=(senitiel) const noexcept { return Size != index; }
 
-    [[nodiscard]] friend constexpr bool operator==(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator==(senitiel, const sized_iterator it) noexcept
     {
       return Size == it.index;
     }
 
 
-    [[nodiscard]] friend constexpr bool operator!=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator!=(senitiel, const sized_iterator it) noexcept
     {
       return Size != it.index;
     }
 
 
-    [[nodiscard]] constexpr bool operator<(const sized_iterator that) const noexcept { return index < that.index; };
-    [[nodiscard]] constexpr bool operator>(const sized_iterator that) const noexcept { return index > that.index; };
-    [[nodiscard]] constexpr bool operator<=(const sized_iterator that) const noexcept { return index <= that.index; };
-    [[nodiscard]] constexpr bool operator>=(const sized_iterator that) const noexcept { return index >= that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<(const sized_iterator that) const noexcept { return index < that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>(const sized_iterator that) const noexcept { return index > that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<=(const sized_iterator that) const noexcept { return index <= that.index; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>=(const sized_iterator that) const noexcept { return index >= that.index; };
 
-    [[nodiscard]] constexpr bool operator<(senitiel) const noexcept { return index < Size; };
-    [[nodiscard]] constexpr bool operator>(senitiel) const noexcept { return index > Size; };
-    [[nodiscard]] constexpr bool operator<=(senitiel) const noexcept { return index <= Size; };
-    [[nodiscard]] constexpr bool operator>=(senitiel) const noexcept { return index >= Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<(senitiel) const noexcept { return index < Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>(senitiel) const noexcept { return index > Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator<=(senitiel) const noexcept { return index <= Size; };
+    ENCHANTUM_DETAILS_NODISCARD constexpr bool operator>=(senitiel) const noexcept { return index >= Size; };
 
-    [[nodiscard]] friend constexpr bool operator<(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator<(senitiel, const sized_iterator it) noexcept
     {
       return Size < it.index;
     };
-    [[nodiscard]] friend constexpr bool operator>(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator>(senitiel, const sized_iterator it) noexcept
     {
       return Size > it.index;
     };
-    [[nodiscard]] friend constexpr bool operator<=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator<=(senitiel, const sized_iterator it) noexcept
     {
       return Size <= it.index;
     };
-    [[nodiscard]] friend constexpr bool operator>=(senitiel, const sized_iterator it) noexcept
+    ENCHANTUM_DETAILS_NODISCARD friend constexpr bool operator>=(senitiel, const sized_iterator it) noexcept
     {
       return Size >= it.index;
     };
@@ -2250,20 +2252,20 @@ namespace details {
 
   template<typename E, typename String = string_view, bool NullTerminated = true>
   struct names_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = String;
       using base::operator+=;
-      [[nodiscard]] constexpr String operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator*() const noexcept
       {
         const auto* const p       = details::reflection_string_indices<E, NullTerminated>.data();
         const auto* const strings = details::reflection_data_string_storage<E, NullTerminated>.data();
         return String(strings + p[this->index], p[this->index + 1] - p[this->index] - NullTerminated);
       }
 
-      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -2271,10 +2273,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);
@@ -2284,19 +2286,19 @@ namespace details {
 
   template<typename E>
   struct values_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = E;
       using base::operator+=;
-      [[nodiscard]] constexpr E dereference(std::true_type, std::false_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::true_type, std::false_type) const noexcept
       {
         using T = typename std::underlying_type<E>::type;
         return static_cast<E>(static_cast<T>(min<E>) + static_cast<T>(this->index));
       }
 
-      [[nodiscard]] constexpr E dereference(std::false_type, std::true_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::false_type, std::true_type) const noexcept
       {
         using T                        = typename std::underlying_type<E>::type;
         using UT                       = typename std::make_unsigned<T>::type;
@@ -2306,17 +2308,17 @@ namespace details {
         return static_cast<E>(UT{1} << (real_min_offset + static_cast<UT>(this->index - has_zero_flag<E>)));
       }
 
-      [[nodiscard]] constexpr E dereference(std::false_type, std::false_type) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E dereference(std::false_type, std::false_type) const noexcept
       {
         return values<E>[static_cast<std::size_t>(this->index)];
       }
 
-      [[nodiscard]] constexpr E operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E operator*() const noexcept
       {
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
-      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr E operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -2324,10 +2326,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);
@@ -2337,20 +2339,20 @@ namespace details {
 
   template<typename E, typename Pair = std::pair<E, string_view>, bool NullTerminated = true>
   struct entries_generator_t {
-    [[nodiscard]] static constexpr std::size_t size() noexcept { return count<E>; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr std::size_t size() noexcept { return count<E>; }
 
     struct iterator : sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())> {
       using base       = sized_iterator<iterator, static_cast<std::ptrdiff_t>(size())>;
       using value_type = Pair;
       using base::operator+=;
-      [[nodiscard]] constexpr Pair operator*() const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr Pair operator*() const noexcept
       {
         return Pair{
           values_generator_t<E>{}[static_cast<std::size_t>(this->index)],
           names_generator_t<E, string_view, NullTerminated>{}[static_cast<std::size_t>(this->index)],
         };
       }
-      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
       {
         auto it = *this;
         it += i;
@@ -2358,10 +2360,10 @@ namespace details {
       }
     };
 
-    [[nodiscard]] static constexpr auto begin() { return iterator{}; }
-    [[nodiscard]] static constexpr auto end() { return senitiel{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto begin() { return iterator{}; }
+    ENCHANTUM_DETAILS_NODISCARD static constexpr auto end() { return senitiel{}; }
 
-    [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr auto operator[](const std::size_t i) const noexcept
     {
       auto it = begin();
       it += static_cast<std::ptrdiff_t>(i);
@@ -2553,19 +2555,19 @@ namespace details {
 
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const std::underlying_type_t<E> value) noexcept
 {
   return details::contains_value<E>(value);
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const E value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const E value) noexcept
 {
   return enchantum::contains<E>(static_cast<std::underlying_type_t<E>>(value));
 }
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains(const string_view name) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name) noexcept
 {
   constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
   const auto size = name.size();
@@ -2582,7 +2584,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 
 
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
 {
   for (std::size_t i = 0; i < count<E>; ++i) {
     const auto s = names_generator<E>[i];
@@ -2596,7 +2598,7 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
 namespace details {
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   struct index_to_enum_functor {
-    [[nodiscard]] constexpr optional<E> operator()(const std::size_t index) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const std::size_t index) const noexcept
     {
       if (index < count<E>)
         return optional<E>(values_generator<E>[index]);
@@ -2606,7 +2608,7 @@ namespace details {
 
   struct enum_to_index_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr optional<std::size_t> operator()(const E e) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<std::size_t> operator()(const E e) const noexcept
     {
       return details::enum_to_index_impl<E>(e,
                                             std::integral_constant<bool, is_contiguous<E> && count<E> != 0>{},
@@ -2617,14 +2619,14 @@ namespace details {
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   struct cast_functor {
-    [[nodiscard]] constexpr optional<E> operator()(const std::underlying_type_t<E> value) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const std::underlying_type_t<E> value) const noexcept
     {
       if (!enchantum::contains<E>(value))
         return optional<E>();
       return optional<E>(static_cast<E>(value));
     }
 
-    [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name) const noexcept
     {
       constexpr auto minmax = details::minmax_string_size(names<E>.data(), names<E>.data() + names<E>.size());
       const auto size = name.size();
@@ -2640,7 +2642,7 @@ namespace details {
     }
 
     template<typename BinaryPred>
-    [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_pred) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name, const BinaryPred binary_pred) const noexcept
     {
 
       for (std::size_t i = 0; i < count<E>; ++i) {
@@ -2666,7 +2668,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr details::cast_functor<E> cast{};
 namespace details {
   struct to_string_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr string_view operator()(const E value) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr string_view operator()(const E value) const noexcept
     {
       if (const auto i = enchantum::enum_to_index(value))
         return names_generator<E>[*i];
@@ -2718,7 +2720,7 @@ ENCHANTUM_DETAILS_INLINE_VAR constexpr E value_ors = details::value_ors_impl<E>(
 
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const std::underlying_type_t<E> value) noexcept
 {
   if (!has_zero_flag<E>)
     if (value == 0)
@@ -2728,13 +2730,13 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const E value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const E value) noexcept
 {
   return enchantum::contains_bitflag<E>(static_cast<std::underlying_type_t<E>>(value));
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
 {
   std::size_t pos = 0;
   for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -2747,7 +2749,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
 {
   std::size_t pos = 0;
   for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -2760,7 +2762,7 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 
 
 template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
+ENCHANTUM_DETAILS_NODISCARD constexpr String to_string_bitflag(const E value, const char sep = '|')
 {
   using T = std::underlying_type_t<E>;
   if (has_zero_flag<E>)
@@ -2785,7 +2787,7 @@ template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
 {
   using T = std::underlying_type_t<E>;
   T           check_value{};
@@ -2804,13 +2806,13 @@ template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
 {
   return enchantum::cast_bitflag<E>(s, sep, details::equal_to_string_view{});
 }
 
 template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const std::underlying_type_t<E> value) noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const std::underlying_type_t<E> value) noexcept
 {
   return enchantum::contains_bitflag<E>(value) ? optional<E>(static_cast<E>(value)) : optional<E>();
 }
@@ -2961,26 +2963,26 @@ public:
   using Container::at;
   using Container::operator[];
 
-  [[nodiscard]] constexpr reference at(const E index)
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference at(const E index)
   {
     if (const auto i = enchantum::enum_to_index(index))
       return operator[](*i);
     ENCHANTUM_THROW(std::out_of_range("enchantum::array::at index out of range"), index);
   }
 
-  [[nodiscard]] constexpr const_reference at(const E index) const
+  ENCHANTUM_DETAILS_NODISCARD constexpr const_reference at(const E index) const
   {
     if (const auto i = enchantum::enum_to_index(index))
       return operator[](*i);
     ENCHANTUM_THROW(std::out_of_range("enchantum::array::at: index out of range"), index);
   }
 
-  [[nodiscard]] constexpr reference operator[](const E index) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference operator[](const E index) noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
 
-  [[nodiscard]] constexpr const_reference operator[](const E index) const noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr const_reference operator[](const E index) const noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
@@ -3021,7 +3023,7 @@ public:
 
   constexpr bitset() = default;
 
-  [[nodiscard]] string to_string(const char sep = '|') const
+  ENCHANTUM_DETAILS_NODISCARD string to_string(const char sep = '|') const
   {
     string name;
     for (std::size_t i = 0; i < enchantum::count<E>; ++i) {
@@ -3035,7 +3037,7 @@ public:
     return name;
   }
 
-  [[nodiscard]] constexpr auto to_string(const char zero, const char one) const
+  ENCHANTUM_DETAILS_NODISCARD constexpr auto to_string(const char zero, const char one) const
   {
     return Container::to_string(zero, one);
   }
@@ -3047,12 +3049,12 @@ public:
     }
   }
 
-  [[nodiscard]] constexpr reference operator[](const E index) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr reference operator[](const E index) noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
 
-  [[nodiscard]] constexpr bool operator[](const E index) const noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool operator[](const E index) const noexcept
   {
     return operator[](*enchantum::enum_to_index(index));
   }
@@ -3115,27 +3117,27 @@ namespace enchantum {
 namespace bitwise_operators {
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator~(E e) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator~(E e) noexcept
   {
     return static_cast<E>(~static_cast<std::underlying_type_t<E>>(e));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator|(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator|(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) | static_cast<T>(b));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator&(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator&(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) & static_cast<T>(b));
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr E operator^(E a, E b) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr E operator^(E a, E b) noexcept
   {
     using T = std::underlying_type_t<E>;
     return static_cast<E>(static_cast<T>(a) ^ static_cast<T>(b));
@@ -3166,17 +3168,17 @@ namespace bitwise_operators {
 } // namespace enchantum
 
 #define ENCHANTUM_DEFINE_BITWISE_FOR(Enum)                                                \
-  [[nodiscard]] constexpr Enum operator&(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator&(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) & static_cast<T>(b));                      \
   }                                                                                       \
-  [[nodiscard]] constexpr Enum operator|(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator|(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) | static_cast<T>(b));                      \
   }                                                                                       \
-  [[nodiscard]] constexpr Enum operator^(Enum a, Enum b) noexcept                         \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator^(Enum a, Enum b) noexcept                         \
   {                                                                                       \
     using T = std::underlying_type_t<Enum>;                                               \
     return static_cast<Enum>(static_cast<T>(a) ^ static_cast<T>(b));                      \
@@ -3184,7 +3186,7 @@ namespace bitwise_operators {
   constexpr Enum&              operator&=(Enum& a, Enum b) noexcept { return a = a & b; } \
   constexpr Enum&              operator|=(Enum& a, Enum b) noexcept { return a = a | b; } \
   constexpr Enum&              operator^=(Enum& a, Enum b) noexcept { return a = a ^ b; } \
-  [[nodiscard]] constexpr Enum operator~(Enum a) noexcept                                 \
+  ENCHANTUM_DETAILS_NODISCARD constexpr Enum operator~(Enum a) noexcept                                 \
   {                                                                                       \
     return static_cast<Enum>(~static_cast<std::underlying_type_t<Enum>>(a));              \
   }
@@ -3215,14 +3217,14 @@ namespace scoped {
   } // namespace details
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-  [[nodiscard]] constexpr bool contains(const string_view name) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name) noexcept
   {
     const auto n = details::remove_scope_or_empty(name, type_name<E>);
     return !n.empty() && enchantum::contains<E>(n);
   }
 
   template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPredicate>
-  [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPredicate binary_predicate) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains(const string_view name, const BinaryPredicate binary_predicate) noexcept
   {
     const auto n = details::remove_scope_or_empty(name, type_name<E>);
     return !n.empty() && enchantum::contains<E>(n, binary_predicate);
@@ -3231,14 +3233,14 @@ namespace scoped {
   namespace details {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
     struct scoped_cast_functor {
-      [[nodiscard]] constexpr optional<E> operator()(const string_view name) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
         return n.empty() ? optional<E>() : enchantum::cast<E>(n);
       }
 
       template<typename BinaryPred>
-      [[nodiscard]] constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const string_view name, const BinaryPred binary_predicate) const noexcept
       {
         const auto n = details::remove_scope_or_empty(name, type_name<E>);
         return n.empty() ? optional<E>() : enchantum::cast<E>(n, binary_predicate);
@@ -3248,7 +3250,7 @@ namespace scoped {
     struct to_scoped_string_functor {
       // hacky workaround about string not being a literal type.
       template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename String = string>
-      [[nodiscard]] constexpr String operator()(const E value) const noexcept
+      ENCHANTUM_DETAILS_NODISCARD constexpr String operator()(const E value) const noexcept
       {
         String s;
         if (const auto i = enchantum::enum_to_index(value)) {
@@ -3271,7 +3273,7 @@ namespace scoped {
   ENCHANTUM_DETAILS_INLINE_VAR constexpr details::scoped_cast_functor<E> cast;
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
   {
     std::size_t pos = 0;
     for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -3283,7 +3285,7 @@ namespace scoped {
   }
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-  [[nodiscard]] constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr bool contains_bitflag(const string_view s, const char sep = '|') noexcept
   {
     std::size_t pos = 0;
     for (std::size_t i = s.find(sep); i != s.npos; i = s.find(sep, pos)) {
@@ -3296,7 +3298,7 @@ namespace scoped {
 
 
   template<typename String = string, ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-  [[nodiscard]] constexpr String to_string_bitflag(const E value, const char sep = '|')
+  ENCHANTUM_DETAILS_NODISCARD constexpr String to_string_bitflag(const E value, const char sep = '|')
   {
     using T = std::underlying_type_t<E>;
     if (has_zero_flag<E>)
@@ -3325,7 +3327,7 @@ namespace scoped {
 
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E), typename BinaryPred>
-  [[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
+  ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep, const BinaryPred binary_pred) noexcept
   {
     using T = std::underlying_type_t<E>;
     T           check_value{};
@@ -3344,7 +3346,7 @@ namespace scoped {
   }
 
   template<ENCHANTUM_DETAILS_ENUM_BITFLAG_CONCEPT(E)>
-[[nodiscard]] constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
+ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> cast_bitflag(const string_view s, const char sep = '|') noexcept
 {
   return enchantum::scoped::cast_bitflag<E>(s, sep, enchantum::details::equal_to_string_view{});
 }
@@ -3414,7 +3416,7 @@ namespace details {
   template<std::ptrdiff_t N>
   struct next_value_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       if (!enchantum::contains(value))
         return optional<E>();
@@ -3429,7 +3431,7 @@ namespace details {
   template<std::ptrdiff_t N>
   struct next_value_circular_functor {
     template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
-    [[nodiscard]] constexpr E operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
+    ENCHANTUM_DETAILS_NODISCARD constexpr E operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       ENCHANTUM_ASSERT(enchantum::contains(value), "next/prev_value_circular requires 'value' to be a valid enum member", value);
       const auto     i     = static_cast<std::ptrdiff_t>(*enchantum::enum_to_index(value));

--- a/single_include/enchantum_single_header.hpp
+++ b/single_include/enchantum_single_header.hpp
@@ -257,6 +257,7 @@ namespace details {
   {
     using R = typename std::common_type<T, U>::type;
     return static_cast<R>(a) < static_cast<R>(b) ? static_cast<R>(b) : static_cast<R>(a);
+  }
 
   template<typename T, typename U>
   constexpr auto Min(T a, U b)
@@ -1116,6 +1117,18 @@ namespace details {
     }
   }
 
+  constexpr const char* find_char(const char* s, const std::size_t count, const char c) noexcept
+  {
+#if ENCHANTUM_DETAILS_CXX_STD >= 201703L
+    return std::char_traits<char>::find(s, count, c);
+#else
+    for (std::size_t i = 0; i < count; ++i)
+      if (s[i] == c)
+        return s + i;
+    return nullptr;
+#endif
+  }
+
   template<typename E, E... Vs>
   constexpr auto var_name() noexcept
   {
@@ -1127,7 +1140,7 @@ namespace details {
   {
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(')
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
       else
         return true;
     }
@@ -1152,13 +1165,11 @@ namespace details {
     (void)min; // not always used
     for (std::size_t index = 0; index < array_size; ++index) {
       if (*str == '(') {
-        str = std::char_traits<char>::find(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
+        str = details::find_char(str + least_length_when_casting, UINT8_MAX, ',') + SZC(", ");
       }
       else {
         str += least_length_when_value;
-        // although gcc implementation of std::char_traits::find is using a for loop internally
-        // copying the code of the function makes it way slower to compile, this was surprising.
-        const auto commapos = static_cast<std::size_t>(std::char_traits<char>::find(str, UINT8_MAX, ',') - str);
+        const auto commapos = static_cast<std::size_t>(details::find_char(str, UINT8_MAX, ',') - str);
         if (IsBitFlag)
           values[valid_count] = index == 0 ? IntType{} : static_cast<IntType>(IntType{1} << (index - 1));
         else
@@ -2236,7 +2247,12 @@ namespace details {
         return String(strings + p[this->index], p[this->index + 1] - p[this->index] - NullTerminated);
       }
 
-      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr String operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -2244,7 +2260,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 
@@ -2280,7 +2298,12 @@ namespace details {
         return dereference(std::integral_constant<bool, is_contiguous<E>>{},
                            std::integral_constant<bool, is_contiguous_bitflag<E>>{});
       }
-      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr E operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -2288,7 +2311,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 
@@ -2305,7 +2330,12 @@ namespace details {
           names_generator_t<E, string_view, NullTerminated>{}[static_cast<std::size_t>(this->index)],
         };
       }
-      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept { return *(*this + i); }
+      [[nodiscard]] constexpr Pair operator[](const std::ptrdiff_t i) const noexcept
+      {
+        auto it = *this;
+        it += i;
+        return *it;
+      }
     };
 
     [[nodiscard]] static constexpr auto begin() { return iterator{}; }
@@ -2313,7 +2343,9 @@ namespace details {
 
     [[nodiscard]] constexpr auto operator[](const std::size_t i) const noexcept
     {
-      return *(begin() + static_cast<std::ptrdiff_t>(i));
+      auto it = begin();
+      it += static_cast<std::ptrdiff_t>(i);
+      return *it;
     }
   };
 
@@ -2444,8 +2476,8 @@ namespace details {
   constexpr bool contains_impl(typename std::underlying_type<E>::type value, std::false_type, std::false_type) noexcept
   {
     using T = typename std::underlying_type<E>::type;
-    for (const auto v : values_generator<E>)
-      if (static_cast<T>(v) == value)
+    for (std::size_t i = 0; i < count<E>; ++i)
+      if (static_cast<T>(values_generator<E>[i]) == value)
         return true;
     return false;
   }
@@ -2518,9 +2550,11 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
   if (size < minmax.first || size > minmax.second)
     return false;
 
-  for (const auto s : names_generator<E>)
+  for (std::size_t i = 0; i < count<E>; ++i) {
+    const auto s = names_generator<E>[i];
     if (s == name)
       return true;
+  }
   return false;
 }
 
@@ -2528,9 +2562,11 @@ template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E)>
 template<ENCHANTUM_DETAILS_ENUM_CONCEPT(E), typename BinaryPred>
 [[nodiscard]] constexpr bool contains(const string_view name, const BinaryPred binary_pred) noexcept
 {
-  for (const auto s : names_generator<E>)
+  for (std::size_t i = 0; i < count<E>; ++i) {
+    const auto s = names_generator<E>[i];
     if (details::call_predicate(binary_pred, name, s))
       return true;
+  }
   return false;
 }
 
@@ -2649,8 +2685,8 @@ namespace details {
     static_assert(is_bitflag<E>, "");
     using T = std::underlying_type_t<E>;
     T ret{};
-    for (const auto val : values_generator<E>)
-      ret |= static_cast<T>(val);
+    for (std::size_t i = 0; i < count<E>; ++i)
+      ret |= static_cast<T>(values_generator<E>[i]);
     return static_cast<E>(ret);
   }
 } // namespace details
@@ -3357,12 +3393,12 @@ namespace details {
     [[nodiscard]] constexpr optional<E> operator()(const E value, const std::ptrdiff_t n = 1) const noexcept
     {
       if (!enchantum::contains(value))
-        return optional<E>{};
+        return optional<E>();
 
       const auto index = static_cast<std::ptrdiff_t>(*enchantum::enum_to_index(value)) + (n * N);
       if (index >= 0 && index < static_cast<std::ptrdiff_t>(count<E>))
-        return optional<E>{values_generator<E>[static_cast<std::size_t>(index)]};
-      return optional<E>{};
+        return optional<E>(values_generator<E>[static_cast<std::size_t>(index)]);
+      return optional<E>();
     }
   };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,14 @@ file(GLOB SRCS "*.cpp" "*.hpp")
 list(REMOVE_ITEM SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cpp14_smoke.cpp")
 list(REMOVE_ITEM SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cpp14_single_header.cpp")
 
+set(CPP14_SRCS ${SRCS})
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/concepts.cpp")
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/double_include.cpp")
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/fmt_format.cpp")
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/iostream.cpp")
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/std_format.cpp")
+list(REMOVE_ITEM CPP14_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/single_header.cpp")
+
 
 get_target_property(STD tests CXX_STANDARD)
 
@@ -83,6 +91,27 @@ target_include_directories(tests_cpp14 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(tests_cpp14 PRIVATE enchantum::enchantum)
 add_test(NAME tests_cpp14 COMMAND tests_cpp14)
 
+add_executable(tests_cpp14_full)
+target_include_directories(tests_cpp14_full PRIVATE "third_party" ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(tests_cpp14_full PRIVATE cxx_std_14)
+set_target_properties(tests_cpp14_full PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+)
+target_compile_definitions(tests_cpp14_full PRIVATE ENCHANTUM_CONFIG_FILE="cpp14_config.hpp")
+if(ENCHANTUM_RUNTIME_TESTS)
+  target_compile_definitions(tests_cpp14_full PRIVATE CATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
+endif()
+target_link_libraries(tests_cpp14_full PRIVATE enchantum::enchantum Catch2::Catch2WithMain)
+if(MSVC)
+  target_compile_options(tests_cpp14_full PRIVATE /Za /permissive-)
+  target_compile_options(tests_cpp14_full PRIVATE /WX /W4)
+else()
+  target_compile_options(tests_cpp14_full PRIVATE -Werror -Wall -Wextra -Wshadow -Wconversion -Wpedantic)
+endif()
+target_sources(tests_cpp14_full PRIVATE ${CPP14_SRCS})
+
 add_executable(tests_cpp14_single_header cpp14_single_header.cpp cpp14_config.hpp)
 target_compile_features(tests_cpp14_single_header PRIVATE cxx_std_14)
 set_target_properties(tests_cpp14_single_header PROPERTIES
@@ -96,6 +125,7 @@ add_test(NAME tests_cpp14_single_header COMMAND tests_cpp14_single_header)
 include(CTest)
 include(Catch)
 catch_discover_tests(tests)
+catch_discover_tests(tests_cpp14_full TEST_PREFIX "cpp14_full::")
 catch_discover_tests(tests_config)
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,7 +88,7 @@ set_target_properties(tests_cpp14 PROPERTIES
 )
 target_compile_definitions(tests_cpp14 PRIVATE ENCHANTUM_CONFIG_FILE="cpp14_config.hpp")
 target_include_directories(tests_cpp14 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(tests_cpp14 PRIVATE enchantum::enchantum)
+target_link_libraries(tests_cpp14 PRIVATE enchantum::enchantum-cxx14)
 add_test(NAME tests_cpp14 COMMAND tests_cpp14)
 
 add_executable(tests_cpp14_full)
@@ -103,7 +103,7 @@ target_compile_definitions(tests_cpp14_full PRIVATE ENCHANTUM_CONFIG_FILE="cpp14
 if(ENCHANTUM_RUNTIME_TESTS)
   target_compile_definitions(tests_cpp14_full PRIVATE CATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 endif()
-target_link_libraries(tests_cpp14_full PRIVATE enchantum::enchantum Catch2::Catch2WithMain)
+target_link_libraries(tests_cpp14_full PRIVATE enchantum::enchantum-cxx14 Catch2::Catch2WithMain)
 if(MSVC)
   target_compile_options(tests_cpp14_full PRIVATE /Za /permissive-)
   target_compile_options(tests_cpp14_full PRIVATE /WX /W4)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ else()
 endif()
 
 file(GLOB SRCS "*.cpp" "*.hpp")
+list(REMOVE_ITEM SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cpp14_smoke.cpp")
+list(REMOVE_ITEM SRCS "${CMAKE_CURRENT_SOURCE_DIR}/cpp14_single_header.cpp")
 
 
 get_target_property(STD tests CXX_STANDARD)
@@ -68,6 +70,28 @@ target_compile_definitions(tests_config PRIVATE ENCHANTUM_CONFIG_FILE="config_te
 target_sources(tests_config PRIVATE config_test/config.cpp config_test/config.hpp)
 target_include_directories(tests_config PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(tests_config Catch2::Catch2WithMain enchantum::enchantum)
+
+add_executable(tests_cpp14 cpp14_smoke.cpp cpp14_config.hpp)
+target_compile_features(tests_cpp14 PRIVATE cxx_std_14)
+set_target_properties(tests_cpp14 PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+)
+target_compile_definitions(tests_cpp14 PRIVATE ENCHANTUM_CONFIG_FILE="cpp14_config.hpp")
+target_include_directories(tests_cpp14 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(tests_cpp14 PRIVATE enchantum::enchantum)
+add_test(NAME tests_cpp14 COMMAND tests_cpp14)
+
+add_executable(tests_cpp14_single_header cpp14_single_header.cpp cpp14_config.hpp)
+target_compile_features(tests_cpp14_single_header PRIVATE cxx_std_14)
+set_target_properties(tests_cpp14_single_header PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+)
+target_include_directories(tests_cpp14_single_header PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME tests_cpp14_single_header COMMAND tests_cpp14_single_header)
 
 include(CTest)
 include(Catch)

--- a/tests/algorithms.cpp
+++ b/tests/algorithms.cpp
@@ -5,10 +5,10 @@
 
 TEMPLATE_LIST_TEST_CASE("for_each", "[algorithms][for_each]", AllEnumsTestTypes)
 {
-  std::vector<std::string_view> names;
+  std::vector<enchantum::string_view> names;
 
   enchantum::for_each<TestType>([&names](const auto c) {
-    if constexpr (c != enchantum::values<TestType>[0])
+    if (c.value != enchantum::values<TestType>[0])
       names.emplace_back(enchantum::to_string(c.value));
   });
   CHECK(names.size() + 1 == enchantum::count<TestType>);

--- a/tests/array.cpp
+++ b/tests/array.cpp
@@ -40,16 +40,15 @@ TEST_CASE("enum array", "[containers][array]")
   CHECK_THROWS_AS(array.at(static_cast<Country>(0xdead / 2)), std::out_of_range);
 
 
-  const enchantum::array<Country, std::string> array2 = {{
-    "Wait who's brandon?",
-    "Capital, not a country",
-    "Le French",
-    "Not in the UN yet",
-    "Anime",
-    "The great country of Europe",
-    "Online-only country",
-    "Underwater with Posidon",
-  }};
+  enchantum::array<Country, std::string> array2;
+  array2[Country::Brandon]    = "Wait who's brandon?";
+  array2[Country::London]     = "Capital, not a country";
+  array2[Country::French]     = "Le French";
+  array2[Country::Earth]      = "Not in the UN yet";
+  array2[Country::Asia]       = "Anime";
+  array2[Country::Europe]     = "The great country of Europe";
+  array2[Country::LeInternet] = "Online-only country";
+  array2[Country::Atlantis]   = "Underwater with Posidon";
   CHECK(array == array2);
   CHECK_FALSE(array != array2);
 }

--- a/tests/bitflags.cpp
+++ b/tests/bitflags.cpp
@@ -10,7 +10,6 @@
 #include <enchantum/iostream.hpp>
 #include <iostream>
 #include <sstream>
-#include <string_view>
 
 
 namespace {
@@ -241,14 +240,16 @@ TEMPLATE_LIST_TEST_CASE("bitflags", "[bitflags]", AllFlagsTestTypes)
   SECTION("cast_bitflag(to_string_bitflag(enum)) == enum")
   {
     for (const auto comb : combinations) {
-      CHECK(comb == enchantum::cast_bitflag<TestType>(enchantum::to_string_bitflag(comb)));
+      const auto string = enchantum::to_string_bitflag(comb);
+      CHECK(comb == enchantum::cast_bitflag<TestType>(enchantum::string_view(string.data(), string.size())));
     }
   }
 
   SECTION("contains_bitflag(to_string_bitflag(enum))")
   {
     for (const auto comb : combinations) {
-      CHECK(enchantum::contains_bitflag<TestType>(enchantum::to_string_bitflag(comb)));
+      const auto string = enchantum::to_string_bitflag(comb);
+      CHECK(enchantum::contains_bitflag<TestType>(enchantum::string_view(string.data(), string.size())));
     }
   }
 
@@ -270,9 +271,11 @@ TEMPLATE_LIST_TEST_CASE("bitflags", "[bitflags]", AllFlagsTestTypes)
   {
     const auto string = []() {
       std::string ret;
-      for (const auto& [e, s] : enchantum::entries<TestType>) {
+      for (const auto& entry : enchantum::entries<TestType>) {
+        const auto e = entry.first;
+        const auto s = entry.second;
         if (T(e) != 0) {
-          ret += s;
+          ret.append(s.data(), s.size());
           if (e != enchantum::max<TestType>)
             ret += '|';
         }
@@ -298,7 +301,7 @@ TEMPLATE_LIST_TEST_CASE("contains_bitflag returns false for invalid combinations
     }
   }
 
-  if constexpr (enchantum::has_zero_flag<TestType>)
+  if (enchantum::has_zero_flag<TestType>)
     CHECK(enchantum::contains_bitflag(TestType{}));
 
   for (const auto comb : invalid_combinations)

--- a/tests/case_insensitive.hpp
+++ b/tests/case_insensitive.hpp
@@ -1,20 +1,20 @@
 #pragma once
 #include <cstddef>
-#include <string_view>
+#include <enchantum/details/string_view.hpp>
 
 struct CaseInsenitive {
+  static constexpr char tolower(const char c) { return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c; }
 
   constexpr bool operator()(const char a, const char b) const
   {
-    constexpr auto tolower = [](const char c) { return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c; };
     return tolower(a) == tolower(b);
   }
 };
 
-inline constexpr CaseInsenitive case_insensitive;
+constexpr CaseInsenitive case_insensitive{};
 
 struct CaseInsenitiveByStrings {
-  constexpr bool operator()(const std::string_view a, const std::string_view b) const
+  constexpr bool operator()(const enchantum::string_view a, const enchantum::string_view b) const
   {
     if (a.size() != b.size())
       return false;
@@ -26,7 +26,7 @@ struct CaseInsenitiveByStrings {
   }
 };
 
-inline constexpr CaseInsenitiveByStrings case_insensitive_by_strings;
+constexpr CaseInsenitiveByStrings case_insensitive_by_strings{};
 
 
 struct CaseInsenitiveBoth {
@@ -39,4 +39,4 @@ struct CaseInsenitiveBoth {
   }
 };
 
-inline constexpr CaseInsenitiveBoth case_insensitive_both;
+constexpr CaseInsenitiveBoth case_insensitive_both{};

--- a/tests/cpp14_config.hpp
+++ b/tests/cpp14_config.hpp
@@ -1,22 +1,67 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
+
+#if defined(_MSVC_LANG)
+  #define TESTS_CPP14_CXX_STD _MSVC_LANG
+#else
+  #define TESTS_CPP14_CXX_STD __cplusplus
+#endif
 
 namespace tests_cpp14 {
 
 template<typename T>
 struct optional {
   constexpr optional() = default;
-  constexpr optional(T v) : value(v), has_value_(true) {}
+  constexpr optional(T v) : value_(v), has_value_(true) {}
 
   constexpr explicit operator bool() const noexcept { return has_value_; }
   constexpr bool has_value() const noexcept { return has_value_; }
-  constexpr const T& operator*() const noexcept { return value; }
-  constexpr T& operator*() noexcept { return value; }
+  constexpr const T& value() const noexcept { return value_; }
+  constexpr T& value() noexcept { return value_; }
+  constexpr const T& operator*() const noexcept { return value_; }
+  constexpr T& operator*() noexcept { return value_; }
 
-  T    value{};
+  T    value_{};
   bool has_value_ = false;
 };
+
+template<typename T>
+constexpr bool operator==(const optional<T>& a, const T& b) noexcept
+{
+  return a.has_value() && *a == b;
+}
+
+template<typename T>
+constexpr bool operator==(const T& a, const optional<T>& b) noexcept
+{
+  return b == a;
+}
+
+template<typename T>
+constexpr bool operator!=(const optional<T>& a, const T& b) noexcept
+{
+  return !(a == b);
+}
+
+template<typename T>
+constexpr bool operator!=(const T& a, const optional<T>& b) noexcept
+{
+  return !(a == b);
+}
+
+template<typename T>
+constexpr bool operator==(const optional<T>& a, const optional<T>& b) noexcept
+{
+  return a.has_value() == b.has_value() && (!a.has_value() || *a == *b);
+}
+
+template<typename T>
+constexpr bool operator!=(const optional<T>& a, const optional<T>& b) noexcept
+{
+  return !(a == b);
+}
 
 struct string_view {
   static constexpr std::size_t npos = static_cast<std::size_t>(-1);
@@ -24,6 +69,8 @@ struct string_view {
   constexpr string_view() = default;
   constexpr string_view(const char* s) : begin_(s), end_(s + length(s)) {}
   constexpr string_view(const char* s, std::size_t size) : begin_(s), end_(s + size) {}
+  constexpr string_view(const string_view&) = default;
+  string_view(const std::string& s) : begin_(s.data()), end_(s.data() + s.size()) {}
 
   static constexpr std::size_t length(const char* s) noexcept
   {
@@ -41,6 +88,8 @@ struct string_view {
   constexpr const char* end() const noexcept { return end_; }
 
   constexpr char operator[](std::size_t i) const noexcept { return begin_[i]; }
+
+  operator std::string() const { return std::string(data(), size()); }
 
   constexpr void remove_prefix(std::size_t amount) noexcept { begin_ += amount; }
   constexpr void remove_suffix(std::size_t amount) noexcept { end_ -= amount; }

--- a/tests/cpp14_config.hpp
+++ b/tests/cpp14_config.hpp
@@ -70,6 +70,7 @@ struct string_view {
   constexpr string_view(const char* s) : begin_(s), end_(s + length(s)) {}
   constexpr string_view(const char* s, std::size_t size) : begin_(s), end_(s + size) {}
   constexpr string_view(const string_view&) = default;
+  constexpr string_view& operator=(const string_view&) = default;
   string_view(const std::string& s) : begin_(s.data()), end_(s.data() + s.size()) {}
 
   static constexpr std::size_t length(const char* s) noexcept

--- a/tests/cpp14_config.hpp
+++ b/tests/cpp14_config.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstddef>
+
+namespace tests_cpp14 {
+
+template<typename T>
+struct optional {
+  constexpr optional() = default;
+  constexpr optional(T v) : value(v), has_value_(true) {}
+
+  constexpr explicit operator bool() const noexcept { return has_value_; }
+  constexpr bool has_value() const noexcept { return has_value_; }
+  constexpr const T& operator*() const noexcept { return value; }
+  constexpr T& operator*() noexcept { return value; }
+
+  T    value{};
+  bool has_value_ = false;
+};
+
+struct string_view {
+  static constexpr std::size_t npos = static_cast<std::size_t>(-1);
+
+  constexpr string_view() = default;
+  constexpr string_view(const char* s) : begin_(s), end_(s + length(s)) {}
+  constexpr string_view(const char* s, std::size_t size) : begin_(s), end_(s + size) {}
+
+  static constexpr std::size_t length(const char* s) noexcept
+  {
+    std::size_t count = 0;
+    while (s[count] != '\0')
+      ++count;
+    return count;
+  }
+
+  constexpr const char* data() const noexcept { return begin_; }
+  constexpr std::size_t size() const noexcept { return static_cast<std::size_t>(end_ - begin_); }
+  constexpr bool        empty() const noexcept { return begin_ == end_; }
+
+  constexpr const char* begin() const noexcept { return begin_; }
+  constexpr const char* end() const noexcept { return end_; }
+
+  constexpr char operator[](std::size_t i) const noexcept { return begin_[i]; }
+
+  constexpr void remove_prefix(std::size_t amount) noexcept { begin_ += amount; }
+  constexpr void remove_suffix(std::size_t amount) noexcept { end_ -= amount; }
+
+  constexpr string_view substr(std::size_t offset) const noexcept
+  {
+    return offset > size() ? string_view(end_, 0) : string_view(begin_ + offset, size() - offset);
+  }
+
+  constexpr string_view substr(std::size_t offset, std::size_t count) const noexcept
+  {
+    return offset > size() ? string_view(end_, 0) : string_view(begin_ + offset, count > size() - offset ? size() - offset : count);
+  }
+
+  constexpr std::size_t find(char c, std::size_t pos = 0) const noexcept
+  {
+    for (std::size_t i = pos; i < size(); ++i)
+      if (begin_[i] == c)
+        return i;
+    return npos;
+  }
+
+  constexpr std::size_t rfind(char c) const noexcept
+  {
+    for (std::size_t i = size(); i != 0; --i)
+      if (begin_[i - 1] == c)
+        return i - 1;
+    return npos;
+  }
+
+  const char* begin_ = nullptr;
+  const char* end_   = nullptr;
+};
+
+constexpr bool operator==(string_view a, string_view b) noexcept
+{
+  if (a.size() != b.size())
+    return false;
+  for (std::size_t i = 0; i < a.size(); ++i)
+    if (a[i] != b[i])
+      return false;
+  return true;
+}
+
+constexpr bool operator!=(string_view a, string_view b) noexcept { return !(a == b); }
+
+} // namespace tests_cpp14
+
+#define ENCHANTUM_ALIAS_STRING_VIEW using string_view = tests_cpp14::string_view;
+#define ENCHANTUM_ALIAS_OPTIONAL \
+  template<typename T>             \
+  using optional = tests_cpp14::optional<T>;

--- a/tests/cpp14_config.hpp
+++ b/tests/cpp14_config.hpp
@@ -120,6 +120,30 @@ struct string_view {
     return npos;
   }
 
+  constexpr std::size_t rfind(string_view needle) const noexcept
+  {
+    if (needle.empty())
+      return size();
+    if (needle.size() > size())
+      return npos;
+
+    for (std::size_t pos = size() - needle.size() + 1; pos != 0; --pos) {
+      const std::size_t offset = pos - 1;
+      bool              match  = true;
+      for (std::size_t i = 0; i < needle.size(); ++i) {
+        if (begin_[offset + i] != needle[i]) {
+          match = false;
+          break;
+        }
+      }
+      if (match)
+        return offset;
+    }
+    return npos;
+  }
+
+  constexpr std::size_t rfind(const char* s) const noexcept { return rfind(string_view(s)); }
+
   const char* begin_ = nullptr;
   const char* end_   = nullptr;
 };

--- a/tests/cpp14_single_header.cpp
+++ b/tests/cpp14_single_header.cpp
@@ -2,14 +2,29 @@
 #include "../single_include/enchantum_single_header.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 namespace single_header_tests {
 
 enum class SingleColor { Red = 0, Blue = 1 };
 
 enum class SinglePermission { None = 0, Read = 1, Write = 2, Execute = 4 };
+
+struct case_insensitive_char_equal {
+  constexpr char lower(char c) const noexcept
+  {
+    return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+  }
+
+  constexpr bool operator()(char a, char b) const noexcept { return lower(a) == lower(b); }
+};
+
+struct string_view_equal {
+  constexpr bool operator()(enchantum::string_view a, enchantum::string_view b) const noexcept { return a == b; }
+};
 
 constexpr SinglePermission operator~(SinglePermission v)
 {
@@ -57,25 +72,97 @@ int main()
   using single_header_tests::SingleColor;
   using single_header_tests::SinglePermission;
 
+  static_assert(std::is_enum<SingleColor>::value, "single-header test enum must be an enum");
   static_assert(enchantum::count<SingleColor> == 2, "single header reflects C++14 enums");
   static_assert(enchantum::to_string(SingleColor::Blue) == enchantum::string_view("Blue", 4), "single header to_string works");
+  static_assert(enchantum::values<SingleColor>[0] == SingleColor::Red, "single header values work in C++14 constexpr context");
+  static_assert(enchantum::names<SingleColor>[1] == enchantum::string_view("Blue", 4), "single header names work in C++14 constexpr context");
+  static_assert(enchantum::entries<SingleColor>[1].first == SingleColor::Blue,
+                "single header entries values work in C++14 constexpr context");
+  static_assert(enchantum::entries<SingleColor>[1].second == enchantum::string_view("Blue", 4),
+                "single header entries names work in C++14 constexpr context");
+  static_assert(enchantum::names<SingleColor, enchantum::string_view, false>[0] == enchantum::string_view("Red", 3),
+                "single header non-null-terminated names work in C++14 constexpr context");
 
   const std::string scoped_blue = enchantum::scoped::to_string(SingleColor::Blue);
   assert(scoped_blue == "SingleColor::Blue");
 
+  assert((enchantum::contains<SingleColor>(enchantum::string_view("blue", 4), single_header_tests::case_insensitive_char_equal{})));
+  assert((enchantum::contains<SingleColor>(enchantum::string_view("Blue", 4), single_header_tests::string_view_equal{})));
+
   const auto value = enchantum::cast<SingleColor>(enchantum::string_view("Red", 3));
   assert(value && *value == SingleColor::Red);
+
+  const auto blue_case_insensitive =
+    enchantum::cast<SingleColor>(enchantum::string_view("blue", 4), single_header_tests::case_insensitive_char_equal{});
+  assert(blue_case_insensitive && *blue_case_insensitive == SingleColor::Blue);
 
   const auto scoped_value = enchantum::scoped::cast<SingleColor>(enchantum::string_view("SingleColor::Red", 16));
   assert(scoped_value && *scoped_value == SingleColor::Red);
 
+  const auto blue_index = enchantum::enum_to_index(SingleColor::Blue);
+  assert(blue_index && *blue_index == 1u);
+  const auto blue_from_index = enchantum::index_to_enum<SingleColor>(1);
+  assert(blue_from_index && *blue_from_index == SingleColor::Blue);
+
+  assert(enchantum::values_generator<SingleColor>.size() == enchantum::count<SingleColor>);
+  assert(enchantum::values_generator<SingleColor>[0] == SingleColor::Red);
+  assert(enchantum::names_generator<SingleColor>[1] == enchantum::string_view("Blue", 4));
+  assert((enchantum::names_generator<SingleColor, enchantum::string_view, false>[0] == enchantum::string_view("Red", 3)));
+  assert(enchantum::entries_generator<SingleColor>[1].first == SingleColor::Blue);
+  assert(enchantum::entries_generator<SingleColor>[1].second == enchantum::string_view("Blue", 4));
+
+  auto values_it = enchantum::values_generator<SingleColor>.begin();
+  assert(*values_it == SingleColor::Red);
+  assert(values_it[1] == SingleColor::Blue);
+  values_it += 1;
+  assert(*values_it == SingleColor::Blue);
+
+  std::size_t visited_colors = 0;
+  enchantum::for_each<SingleColor>([&visited_colors](const auto color) {
+    assert(enchantum::contains(color.value));
+    ++visited_colors;
+  });
+  assert(visited_colors == enchantum::count<SingleColor>);
+
+  enchantum::array<SingleColor, int> weights{};
+  weights[SingleColor::Red]  = 10;
+  weights[SingleColor::Blue] = 20;
+  assert(weights.size() == enchantum::count<SingleColor>);
+  assert(weights.at(SingleColor::Blue) == 20);
+
+  enchantum::bitset<SingleColor> selected_colors{SingleColor::Red};
+  assert(selected_colors.test(SingleColor::Red));
+  assert(!selected_colors.test(SingleColor::Blue));
+  assert(selected_colors.to_string() == "Red");
+  selected_colors.flip(SingleColor::Blue);
+  assert(selected_colors.to_string('.') == "Red.Blue");
+  selected_colors[SingleColor::Red] = false;
+  assert(!selected_colors.test(SingleColor::Red));
+
+  const auto next = enchantum::next_value(SingleColor::Red);
+  assert(next && *next == SingleColor::Blue);
+  const auto prev = enchantum::prev_value(SingleColor::Blue);
+  assert(prev && *prev == SingleColor::Red);
+  assert(!enchantum::prev_value(SingleColor::Red));
+  assert(enchantum::next_value_circular(SingleColor::Blue) == SingleColor::Red);
+  assert(enchantum::prev_value_circular(SingleColor::Red) == SingleColor::Blue);
+
   static_assert(enchantum::is_bitflag<SinglePermission>, "single header detects bitflag enums");
+  static_assert(enchantum::has_zero_flag<SinglePermission>, "single header detects zero bitflag value");
+  assert(enchantum::contains_bitflag(SinglePermission::Read | SinglePermission::Write));
+  assert(enchantum::contains_bitflag(SinglePermission::None));
+  assert((enchantum::contains_bitflag<SinglePermission>(enchantum::string_view("Read|Execute", 12))));
 
   const std::string permission_name = enchantum::to_string_bitflag(SinglePermission::Read | SinglePermission::Execute);
   assert(permission_name == "Read|Execute");
+  assert(enchantum::to_string_bitflag(SinglePermission::None) == "None");
+  assert(enchantum::to_string_bitflag(SinglePermission::Read | SinglePermission::Write, ',') == "Read,Write");
 
   const auto permission = enchantum::cast_bitflag<SinglePermission>(enchantum::string_view("Read|Write", 10));
   assert(permission && *permission == (SinglePermission::Read | SinglePermission::Write));
+  const auto permission_none = enchantum::cast_bitflag<SinglePermission>(0);
+  assert(permission_none && *permission_none == SinglePermission::None);
 
   const std::string scoped_permission_name = enchantum::scoped::to_string_bitflag(SinglePermission::Read | SinglePermission::Execute);
   assert(scoped_permission_name == "SinglePermission::Read|SinglePermission::Execute");

--- a/tests/cpp14_single_header.cpp
+++ b/tests/cpp14_single_header.cpp
@@ -2,6 +2,7 @@
 #include "../single_include/enchantum_single_header.hpp"
 
 #include <cassert>
+#include <sstream>
 #include <string>
 
 namespace single_header_tests {
@@ -82,4 +83,15 @@ int main()
   const auto scoped_permission =
     enchantum::scoped::cast_bitflag<SinglePermission>(enchantum::string_view("SinglePermission::Read|SinglePermission::Write", 46));
   assert(scoped_permission && *scoped_permission == (SinglePermission::Read | SinglePermission::Write));
+
+  std::istringstream color_stream("Blue");
+  using namespace enchantum::iostream_operators;
+  SingleColor streamed_color{};
+  color_stream >> streamed_color;
+  assert(color_stream && streamed_color == SingleColor::Blue);
+
+  std::istringstream permission_stream("Read|Execute");
+  SinglePermission streamed_permission{};
+  permission_stream >> streamed_permission;
+  assert(permission_stream && streamed_permission == (SinglePermission::Read | SinglePermission::Execute));
 }

--- a/tests/cpp14_single_header.cpp
+++ b/tests/cpp14_single_header.cpp
@@ -1,0 +1,85 @@
+#include "cpp14_config.hpp"
+#include "../single_include/enchantum_single_header.hpp"
+
+#include <cassert>
+#include <string>
+
+namespace single_header_tests {
+
+enum class SingleColor { Red = 0, Blue = 1 };
+
+enum class SinglePermission { None = 0, Read = 1, Write = 2, Execute = 4 };
+
+constexpr SinglePermission operator~(SinglePermission v)
+{
+  return static_cast<SinglePermission>(~static_cast<int>(v));
+}
+
+constexpr SinglePermission operator|(SinglePermission a, SinglePermission b)
+{
+  return static_cast<SinglePermission>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+constexpr SinglePermission operator&(SinglePermission a, SinglePermission b)
+{
+  return static_cast<SinglePermission>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+SinglePermission& operator|=(SinglePermission& a, SinglePermission b)
+{
+  a = a | b;
+  return a;
+}
+
+SinglePermission& operator&=(SinglePermission& a, SinglePermission b)
+{
+  a = a & b;
+  return a;
+}
+
+} // namespace single_header_tests
+
+template<>
+struct enchantum::enum_traits<single_header_tests::SingleColor> {
+  static constexpr int min = 0;
+  static constexpr int max = 1;
+};
+
+template<>
+struct enchantum::enum_traits<single_header_tests::SinglePermission> {
+  static constexpr int min = 0;
+  static constexpr int max = 4;
+};
+
+int main()
+{
+  using single_header_tests::SingleColor;
+  using single_header_tests::SinglePermission;
+
+  static_assert(enchantum::count<SingleColor> == 2, "single header reflects C++14 enums");
+  static_assert(enchantum::to_string(SingleColor::Blue) == enchantum::string_view("Blue", 4), "single header to_string works");
+
+  const std::string scoped_blue = enchantum::scoped::to_string(SingleColor::Blue);
+  assert(scoped_blue == "SingleColor::Blue");
+
+  const auto value = enchantum::cast<SingleColor>(enchantum::string_view("Red", 3));
+  assert(value && *value == SingleColor::Red);
+
+  const auto scoped_value = enchantum::scoped::cast<SingleColor>(enchantum::string_view("SingleColor::Red", 16));
+  assert(scoped_value && *scoped_value == SingleColor::Red);
+
+  static_assert(enchantum::is_bitflag<SinglePermission>, "single header detects bitflag enums");
+
+  const std::string permission_name = enchantum::to_string_bitflag(SinglePermission::Read | SinglePermission::Execute);
+  assert(permission_name == "Read|Execute");
+
+  const auto permission = enchantum::cast_bitflag<SinglePermission>(enchantum::string_view("Read|Write", 10));
+  assert(permission && *permission == (SinglePermission::Read | SinglePermission::Write));
+
+  const std::string scoped_permission_name = enchantum::scoped::to_string_bitflag(SinglePermission::Read | SinglePermission::Execute);
+  assert(scoped_permission_name == "SinglePermission::Read|SinglePermission::Execute");
+
+  const auto scoped_permission =
+    enchantum::scoped::cast_bitflag<SinglePermission>(enchantum::string_view("SinglePermission::Read|SinglePermission::Write", 46));
+  assert(scoped_permission && *scoped_permission == (SinglePermission::Read | SinglePermission::Write));
+}

--- a/tests/cpp14_smoke.cpp
+++ b/tests/cpp14_smoke.cpp
@@ -1,10 +1,15 @@
+#include <enchantum/algorithms.hpp>
+#include <enchantum/array.hpp>
 #include <enchantum/bitflags.hpp>
+#include <enchantum/bitset.hpp>
 #include <enchantum/enchantum.hpp>
+#include <enchantum/generators.hpp>
 #include <enchantum/iostream.hpp>
 #include <enchantum/next_value.hpp>
 #include <enchantum/scoped.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -14,6 +19,19 @@ namespace {
 enum class Color { Red = -1, Green = 0, Blue = 2 };
 
 enum class Permission { None = 0, Read = 1, Write = 2, Execute = 4 };
+
+struct case_insensitive_char_equal {
+  constexpr char lower(char c) const noexcept
+  {
+    return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+  }
+
+  constexpr bool operator()(char a, char b) const noexcept { return lower(a) == lower(b); }
+};
+
+struct string_view_equal {
+  constexpr bool operator()(enchantum::string_view a, enchantum::string_view b) const noexcept { return a == b; }
+};
 
 constexpr Permission operator~(Permission v)
 {
@@ -62,30 +80,92 @@ int main()
   static_assert(enchantum::count<Color> == 3, "Color has three reflected values");
   static_assert(enchantum::contains(Color::Red), "Color::Red is reflected");
   static_assert(enchantum::to_string(Color::Blue) == enchantum::string_view("Blue", 4), "to_string works in C++14 constexpr context");
+  static_assert(enchantum::values<Color>[0] == Color::Red, "values works in C++14 constexpr context");
+  static_assert(enchantum::names<Color>[1] == enchantum::string_view("Green", 5), "names works in C++14 constexpr context");
+  static_assert(enchantum::entries<Color>[2].first == Color::Blue, "entries values work in C++14 constexpr context");
+  static_assert(enchantum::entries<Color>[2].second == enchantum::string_view("Blue", 4), "entries names work in C++14 constexpr context");
+  static_assert(enchantum::names<Color, enchantum::string_view, false>[0] == enchantum::string_view("Red", 3),
+                "non-null-terminated names work in C++14 constexpr context");
 
   const std::string scoped_blue = enchantum::scoped::to_string(Color::Blue);
   assert(scoped_blue == "Color::Blue");
 
+  assert((enchantum::contains<Color>(enchantum::string_view("green", 5), case_insensitive_char_equal{})));
+  assert((enchantum::contains<Color>(enchantum::string_view("Green", 5), string_view_equal{})));
+
   const auto green = enchantum::cast<Color>(enchantum::string_view("Green", 5));
   assert(green && *green == Color::Green);
+
+  const auto blue_case_insensitive = enchantum::cast<Color>(enchantum::string_view("blue", 4), case_insensitive_char_equal{});
+  assert(blue_case_insensitive && *blue_case_insensitive == Color::Blue);
 
   const auto scoped_green = enchantum::scoped::cast<Color>(enchantum::string_view("Color::Green", 12));
   assert(scoped_green && *scoped_green == Color::Green);
 
   const auto blue_index = enchantum::enum_to_index(Color::Blue);
   assert(blue_index && *blue_index == 2u);
+  const auto blue_from_index = enchantum::index_to_enum<Color>(2);
+  assert(blue_from_index && *blue_from_index == Color::Blue);
+
+  assert(enchantum::values_generator<Color>.size() == enchantum::count<Color>);
+  assert(enchantum::values_generator<Color>[0] == Color::Red);
+  assert(enchantum::names_generator<Color>[1] == enchantum::string_view("Green", 5));
+  assert((enchantum::names_generator<Color, enchantum::string_view, false>[2] == enchantum::string_view("Blue", 4)));
+  assert(enchantum::entries_generator<Color>[2].first == Color::Blue);
+  assert(enchantum::entries_generator<Color>[2].second == enchantum::string_view("Blue", 4));
+
+  auto values_it = enchantum::values_generator<Color>.begin();
+  assert(*values_it == Color::Red);
+  assert(values_it[2] == Color::Blue);
+  values_it += 1;
+  assert(*values_it == Color::Green);
+
+  std::size_t visited_colors = 0;
+  enchantum::for_each<Color>([&visited_colors](const auto color) {
+    assert(enchantum::contains(color.value));
+    ++visited_colors;
+  });
+  assert(visited_colors == enchantum::count<Color>);
+
+  enchantum::array<Color, int> weights{};
+  weights[Color::Red]   = 10;
+  weights[Color::Green] = 20;
+  weights[Color::Blue]  = 30;
+  assert(weights.size() == enchantum::count<Color>);
+  assert(weights.at(Color::Blue) == 30);
+
+  enchantum::bitset<Color> selected_colors{Color::Red, Color::Blue};
+  assert(selected_colors.test(Color::Red));
+  assert(!selected_colors.test(Color::Green));
+  assert(selected_colors.to_string() == "Red|Blue");
+  selected_colors.flip(Color::Green);
+  assert(selected_colors.to_string('.') == "Red.Green.Blue");
+  selected_colors[Color::Blue] = false;
+  assert(!selected_colors.test(Color::Blue));
 
   const auto next = enchantum::next_value(Color::Red);
   assert(next && *next == Color::Green);
+  const auto prev = enchantum::prev_value(Color::Blue);
+  assert(prev && *prev == Color::Green);
+  assert(!enchantum::prev_value(Color::Red));
+  assert(enchantum::next_value_circular(Color::Blue) == Color::Red);
+  assert(enchantum::prev_value_circular(Color::Red) == Color::Blue);
 
   static_assert(enchantum::is_bitflag<Permission>, "Permission is detected as a bitflag enum");
+  static_assert(enchantum::has_zero_flag<Permission>, "Permission has an explicit zero flag");
   assert(enchantum::contains_bitflag(Permission::Read | Permission::Write));
+  assert(enchantum::contains_bitflag(Permission::None));
+  assert((enchantum::contains_bitflag<Permission>(enchantum::string_view("Read|Execute", 12))));
 
   const std::string permission_name = enchantum::to_string_bitflag(Permission::Read | Permission::Execute);
   assert(permission_name == "Read|Execute");
+  assert(enchantum::to_string_bitflag(Permission::None) == "None");
+  assert(enchantum::to_string_bitflag(Permission::Read | Permission::Write, ',') == "Read,Write");
 
   const auto permission = enchantum::cast_bitflag<Permission>(enchantum::string_view("Read|Write", 10));
   assert(permission && *permission == (Permission::Read | Permission::Write));
+  const auto permission_none = enchantum::cast_bitflag<Permission>(0);
+  assert(permission_none && *permission_none == Permission::None);
 
   const std::string scoped_permission_name = enchantum::scoped::to_string_bitflag(Permission::Read | Permission::Execute);
   assert(scoped_permission_name == "Permission::Read|Permission::Execute");

--- a/tests/cpp14_smoke.cpp
+++ b/tests/cpp14_smoke.cpp
@@ -1,0 +1,94 @@
+#include <enchantum/bitflags.hpp>
+#include <enchantum/enchantum.hpp>
+#include <enchantum/next_value.hpp>
+#include <enchantum/scoped.hpp>
+
+#include <cassert>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+enum class Color { Red = -1, Green = 0, Blue = 2 };
+
+enum class Permission { None = 0, Read = 1, Write = 2, Execute = 4 };
+
+constexpr Permission operator~(Permission v)
+{
+  return static_cast<Permission>(~static_cast<int>(v));
+}
+
+constexpr Permission operator|(Permission a, Permission b)
+{
+  return static_cast<Permission>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+constexpr Permission operator&(Permission a, Permission b)
+{
+  return static_cast<Permission>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+Permission& operator|=(Permission& a, Permission b)
+{
+  a = a | b;
+  return a;
+}
+
+Permission& operator&=(Permission& a, Permission b)
+{
+  a = a & b;
+  return a;
+}
+
+} // namespace
+
+template<>
+struct enchantum::enum_traits<Color> {
+  static constexpr int min = -1;
+  static constexpr int max = 2;
+};
+
+template<>
+struct enchantum::enum_traits<Permission> {
+  static constexpr int min = 0;
+  static constexpr int max = 4;
+};
+
+int main()
+{
+  static_assert(std::is_enum<Color>::value, "test enum must be an enum");
+  static_assert(enchantum::count<Color> == 3, "Color has three reflected values");
+  static_assert(enchantum::contains(Color::Red), "Color::Red is reflected");
+  static_assert(enchantum::to_string(Color::Blue) == enchantum::string_view("Blue", 4), "to_string works in C++14 constexpr context");
+
+  const std::string scoped_blue = enchantum::scoped::to_string(Color::Blue);
+  assert(scoped_blue == "Color::Blue");
+
+  const auto green = enchantum::cast<Color>(enchantum::string_view("Green", 5));
+  assert(green && *green == Color::Green);
+
+  const auto scoped_green = enchantum::scoped::cast<Color>(enchantum::string_view("Color::Green", 12));
+  assert(scoped_green && *scoped_green == Color::Green);
+
+  const auto blue_index = enchantum::enum_to_index(Color::Blue);
+  assert(blue_index && *blue_index == 2u);
+
+  const auto next = enchantum::next_value(Color::Red);
+  assert(next && *next == Color::Green);
+
+  static_assert(enchantum::is_bitflag<Permission>, "Permission is detected as a bitflag enum");
+  assert(enchantum::contains_bitflag(Permission::Read | Permission::Write));
+
+  const std::string permission_name = enchantum::to_string_bitflag(Permission::Read | Permission::Execute);
+  assert(permission_name == "Read|Execute");
+
+  const auto permission = enchantum::cast_bitflag<Permission>(enchantum::string_view("Read|Write", 10));
+  assert(permission && *permission == (Permission::Read | Permission::Write));
+
+  const std::string scoped_permission_name = enchantum::scoped::to_string_bitflag(Permission::Read | Permission::Execute);
+  assert(scoped_permission_name == "Permission::Read|Permission::Execute");
+
+  const auto scoped_permission =
+    enchantum::scoped::cast_bitflag<Permission>(enchantum::string_view("Permission::Read|Permission::Write", 34));
+  assert(scoped_permission && *scoped_permission == (Permission::Read | Permission::Write));
+}

--- a/tests/cpp14_smoke.cpp
+++ b/tests/cpp14_smoke.cpp
@@ -1,9 +1,11 @@
 #include <enchantum/bitflags.hpp>
 #include <enchantum/enchantum.hpp>
+#include <enchantum/iostream.hpp>
 #include <enchantum/next_value.hpp>
 #include <enchantum/scoped.hpp>
 
 #include <cassert>
+#include <sstream>
 #include <string>
 #include <type_traits>
 
@@ -91,4 +93,15 @@ int main()
   const auto scoped_permission =
     enchantum::scoped::cast_bitflag<Permission>(enchantum::string_view("Permission::Read|Permission::Write", 34));
   assert(scoped_permission && *scoped_permission == (Permission::Read | Permission::Write));
+
+  std::istringstream color_stream("Blue");
+  using namespace enchantum::iostream_operators;
+  Color streamed_color{};
+  color_stream >> streamed_color;
+  assert(color_stream && streamed_color == Color::Blue);
+
+  std::istringstream permission_stream("Read|Execute");
+  Permission streamed_permission{};
+  permission_stream >> streamed_permission;
+  assert(permission_stream && streamed_permission == (Permission::Read | Permission::Execute));
 }

--- a/tests/different_entries_types.cpp
+++ b/tests/different_entries_types.cpp
@@ -3,11 +3,12 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_tostring.hpp>
 #include <enchantum/enchantum.hpp>
+#include <enchantum/details/string_view.hpp>
 
 template<typename E>
 struct ValueAndString {
   E                value;
-  std::string_view string;
+  enchantum::string_view string;
 };
 
 TEMPLATE_LIST_TEST_CASE("KV as entries key-value pair", "[entries][override_key_value_pair]", AllEnumsTestTypes)

--- a/tests/enchantum.cpp
+++ b/tests/enchantum.cpp
@@ -7,10 +7,10 @@
 
 
 template<typename T>
-auto names_of = []() { static_assert(0 == sizeof(T)); };
+auto names_of = []() { static_assert(0 == sizeof(T), "missing names_of specialization"); };
 
 template<typename T>
-auto values_of = []() { static_assert(0 == sizeof(T)); };
+auto values_of = []() { static_assert(0 == sizeof(T), "missing values_of specialization"); };
 
 template<typename T, typename... Ts>
 constexpr std::array<T, 1 + sizeof...(Ts)> make_array(T first, Ts... rest)

--- a/tests/enchantum.cpp
+++ b/tests/enchantum.cpp
@@ -12,100 +12,112 @@ auto names_of = []() { static_assert(0 == sizeof(T)); };
 template<typename T>
 auto values_of = []() { static_assert(0 == sizeof(T)); };
 
+template<typename T, typename... Ts>
+constexpr std::array<T, 1 + sizeof...(Ts)> make_array(T first, Ts... rest)
+{
+  return {{first, rest...}};
+}
+
+#if TESTS_CPP14_CXX_STD < 201703L
+  #define TESTS_CPP14_MAKE_ARRAY(...) make_array(__VA_ARGS__)
+#else
+  #define TESTS_CPP14_MAKE_ARRAY(...) std::array{__VA_ARGS__}
+#endif
+
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedlong_longNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedlong_longNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedlong_longNoZero, 5> values_of<EnumUnderlyingsignedlong_longNoZero> = {EnumUnderlyingsignedlong_longNoZero::value_0,EnumUnderlyingsignedlong_longNoZero::value_1,EnumUnderlyingsignedlong_longNoZero::value_2,EnumUnderlyingsignedlong_longNoZero::value_3,EnumUnderlyingsignedlong_longNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedlong_long> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedlong_long> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedlong_long, 5> values_of<EnumUnderlyingsignedlong_long> = {EnumUnderlyingsignedlong_long::value_0,EnumUnderlyingsignedlong_long::value_1,EnumUnderlyingsignedlong_long::value_2,EnumUnderlyingsignedlong_long::value_3,EnumUnderlyingsignedlong_long::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedlong_longNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedlong_longNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedlong_longNoZero, 5> values_of<EnumUnderlyingunsignedlong_longNoZero> = {EnumUnderlyingunsignedlong_longNoZero::value_0,EnumUnderlyingunsignedlong_longNoZero::value_1,EnumUnderlyingunsignedlong_longNoZero::value_2,EnumUnderlyingunsignedlong_longNoZero::value_3,EnumUnderlyingunsignedlong_longNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedlong_long> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedlong_long> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedlong_long, 5> values_of<EnumUnderlyingunsignedlong_long> = {EnumUnderlyingunsignedlong_long::value_0,EnumUnderlyingunsignedlong_long::value_1,EnumUnderlyingunsignedlong_long::value_2,EnumUnderlyingunsignedlong_long::value_3,EnumUnderlyingunsignedlong_long::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedlongNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedlongNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedlongNoZero, 5> values_of<EnumUnderlyingsignedlongNoZero> = {EnumUnderlyingsignedlongNoZero::value_0,EnumUnderlyingsignedlongNoZero::value_1,EnumUnderlyingsignedlongNoZero::value_2,EnumUnderlyingsignedlongNoZero::value_3,EnumUnderlyingsignedlongNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedlong> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedlong> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedlong, 5> values_of<EnumUnderlyingsignedlong> = {EnumUnderlyingsignedlong::value_0,EnumUnderlyingsignedlong::value_1,EnumUnderlyingsignedlong::value_2,EnumUnderlyingsignedlong::value_3,EnumUnderlyingsignedlong::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedlongNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedlongNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedlongNoZero, 5> values_of<EnumUnderlyingunsignedlongNoZero> = {EnumUnderlyingunsignedlongNoZero::value_0,EnumUnderlyingunsignedlongNoZero::value_1,EnumUnderlyingunsignedlongNoZero::value_2,EnumUnderlyingunsignedlongNoZero::value_3,EnumUnderlyingunsignedlongNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedlong> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedlong> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedlong, 5> values_of<EnumUnderlyingunsignedlong> = {EnumUnderlyingunsignedlong::value_0,EnumUnderlyingunsignedlong::value_1,EnumUnderlyingunsignedlong::value_2,EnumUnderlyingunsignedlong::value_3,EnumUnderlyingunsignedlong::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedintNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedintNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedintNoZero, 5> values_of<EnumUnderlyingsignedintNoZero> = {EnumUnderlyingsignedintNoZero::value_0,EnumUnderlyingsignedintNoZero::value_1,EnumUnderlyingsignedintNoZero::value_2,EnumUnderlyingsignedintNoZero::value_3,EnumUnderlyingsignedintNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedint> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedint> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedint, 5> values_of<EnumUnderlyingsignedint> = {EnumUnderlyingsignedint::value_0,EnumUnderlyingsignedint::value_1,EnumUnderlyingsignedint::value_2,EnumUnderlyingsignedint::value_3,EnumUnderlyingsignedint::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedintNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedintNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedintNoZero, 5> values_of<EnumUnderlyingunsignedintNoZero> = {EnumUnderlyingunsignedintNoZero::value_0,EnumUnderlyingunsignedintNoZero::value_1,EnumUnderlyingunsignedintNoZero::value_2,EnumUnderlyingunsignedintNoZero::value_3,EnumUnderlyingunsignedintNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedint> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedint> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedint, 5> values_of<EnumUnderlyingunsignedint> = {EnumUnderlyingunsignedint::value_0,EnumUnderlyingunsignedint::value_1,EnumUnderlyingunsignedint::value_2,EnumUnderlyingunsignedint::value_3,EnumUnderlyingunsignedint::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedshortNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedshortNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedshortNoZero, 5> values_of<EnumUnderlyingsignedshortNoZero> = {EnumUnderlyingsignedshortNoZero::value_0,EnumUnderlyingsignedshortNoZero::value_1,EnumUnderlyingsignedshortNoZero::value_2,EnumUnderlyingsignedshortNoZero::value_3,EnumUnderlyingsignedshortNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedshort> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedshort> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedshort, 5> values_of<EnumUnderlyingsignedshort> = {EnumUnderlyingsignedshort::value_0,EnumUnderlyingsignedshort::value_1,EnumUnderlyingsignedshort::value_2,EnumUnderlyingsignedshort::value_3,EnumUnderlyingsignedshort::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedshortNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedshortNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedshortNoZero, 5> values_of<EnumUnderlyingunsignedshortNoZero> = {EnumUnderlyingunsignedshortNoZero::value_0,EnumUnderlyingunsignedshortNoZero::value_1,EnumUnderlyingunsignedshortNoZero::value_2,EnumUnderlyingunsignedshortNoZero::value_3,EnumUnderlyingunsignedshortNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedshort> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedshort> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedshort, 5> values_of<EnumUnderlyingunsignedshort> = {EnumUnderlyingunsignedshort::value_0,EnumUnderlyingunsignedshort::value_1,EnumUnderlyingunsignedshort::value_2,EnumUnderlyingunsignedshort::value_3,EnumUnderlyingunsignedshort::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedcharNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedcharNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedcharNoZero, 5> values_of<EnumUnderlyingsignedcharNoZero> = {EnumUnderlyingsignedcharNoZero::value_0,EnumUnderlyingsignedcharNoZero::value_1,EnumUnderlyingsignedcharNoZero::value_2,EnumUnderlyingsignedcharNoZero::value_3,EnumUnderlyingsignedcharNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingsignedchar> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingsignedchar> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingsignedchar, 5> values_of<EnumUnderlyingsignedchar> = {EnumUnderlyingsignedchar::value_0,EnumUnderlyingsignedchar::value_1,EnumUnderlyingsignedchar::value_2,EnumUnderlyingsignedchar::value_3,EnumUnderlyingsignedchar::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedcharNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedcharNoZero> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedcharNoZero, 5> values_of<EnumUnderlyingunsignedcharNoZero> = {EnumUnderlyingunsignedcharNoZero::value_0,EnumUnderlyingunsignedcharNoZero::value_1,EnumUnderlyingunsignedcharNoZero::value_2,EnumUnderlyingunsignedcharNoZero::value_3,EnumUnderlyingunsignedcharNoZero::value_4};
 template<>
-std::array<std::string_view, 5> names_of<EnumUnderlyingunsignedchar> = {"value_0","value_1","value_2","value_3","value_4"};
+std::array<enchantum::string_view, 5> names_of<EnumUnderlyingunsignedchar> = {"value_0","value_1","value_2","value_3","value_4"};
 template<>
 std::array<EnumUnderlyingunsignedchar, 5> values_of<EnumUnderlyingunsignedchar> = {EnumUnderlyingunsignedchar::value_0,EnumUnderlyingunsignedchar::value_1,EnumUnderlyingunsignedchar::value_2,EnumUnderlyingunsignedchar::value_3,EnumUnderlyingunsignedchar::value_4};
 
 template<>
-std::array<std::string_view, 5> names_of<Color> = {"Aqua", "Purple", "Green", "Red", "Blue"};
+std::array<enchantum::string_view, 5> names_of<Color> = {"Aqua", "Purple", "Green", "Red", "Blue"};
 template<>
-std::array<std::string_view, 7> names_of<Flags> = {"Flag0", "Flag1", "Flag2", "Flag3", "Flag4", "Flag5", "Flag6"};
+std::array<enchantum::string_view, 7> names_of<Flags> = {"Flag0", "Flag1", "Flag2", "Flag3", "Flag4", "Flag5", "Flag6"};
 template<>
-std::array<std::string_view, 5> names_of<UnscopedColor> = {"Aqua", "Purple", "Green", "Red", "Blue"};
+std::array<enchantum::string_view, 5> names_of<UnscopedColor> = {"Aqua", "Purple", "Green", "Red", "Blue"};
 template<>
-std::array<std::string_view, 3> names_of<BlockType> = {"Dirt", "Stone", "Obsidian"};
+std::array<enchantum::string_view, 3> names_of<BlockType> = {"Dirt", "Stone", "Obsidian"};
 template<>
-std::array<std::string_view, 7> names_of<StrongFlagsNoOverloadedOperators> =
+std::array<enchantum::string_view, 7> names_of<StrongFlagsNoOverloadedOperators> =
   {"Flag0", "Flag1", "Flag2", "Flag3", "Flag4", "Flag5", "Flag6"};
 template<>
-std::array<std::string_view, 10> names_of<ImGuiFreeTypeBuilderFlags> =
+std::array<enchantum::string_view, 10> names_of<ImGuiFreeTypeBuilderFlags> =
   {"NoHinting",
    "NoAutoHint",
    "ForceAutoHint",
@@ -117,9 +129,9 @@ std::array<std::string_view, 10> names_of<ImGuiFreeTypeBuilderFlags> =
    "LoadColor",
    "Bitmap"};
 template<>
-std::array<std::string_view, 10> names_of<ContigNonZero> = {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
+std::array<enchantum::string_view, 10> names_of<ContigNonZero> = {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
 template<>
-std::array<std::string_view, 10> names_of<ContigNonZeroCStyle> =
+std::array<enchantum::string_view, 10> names_of<ContigNonZeroCStyle> =
   {"ContigNonZeroCStyle_0",
    "ContigNonZeroCStyle_1",
    "ContigNonZeroCStyle_2",
@@ -131,7 +143,7 @@ std::array<std::string_view, 10> names_of<ContigNonZeroCStyle> =
    "ContigNonZeroCStyle_8",
    "ContigNonZeroCStyle_9"};
 template<>
-std::array<std::string_view, 10> names_of<ContigNonZeroStartWith5CStyle> =
+std::array<enchantum::string_view, 10> names_of<ContigNonZeroStartWith5CStyle> =
   {"ContigNonZeroStartWith5CStyle_0",
    "ContigNonZeroStartWith5CStyle_1",
    "ContigNonZeroStartWith5CStyle_2",
@@ -143,79 +155,79 @@ std::array<std::string_view, 10> names_of<ContigNonZeroStartWith5CStyle> =
    "ContigNonZeroStartWith5CStyle_8",
    "ContigNonZeroStartWith5CStyle_9"};
 template<>
-std::array<std::string_view, 10> names_of<UnderlyingTypeWChar_t> =
+std::array<enchantum::string_view, 10> names_of<UnderlyingTypeWChar_t> =
   {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
 #ifdef __cpp_char8_t
 template<>
-std::array<std::string_view, 10> names_of<UnderlyingTypeChar8_t> =
+std::array<enchantum::string_view, 10> names_of<UnderlyingTypeChar8_t> =
   {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
 #endif
 template<>
-std::array<std::string_view, 10> names_of<UnderlyingTypeChar16_t> =
+std::array<enchantum::string_view, 10> names_of<UnderlyingTypeChar16_t> =
   {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
 template<>
-std::array<std::string_view, 10> names_of<UnderlyingTypeChar32_t> =
+std::array<enchantum::string_view, 10> names_of<UnderlyingTypeChar32_t> =
   {"_0", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"};
 template<>
-std::array<std::string_view, 26> names_of<Letters> = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+std::array<enchantum::string_view, 26> names_of<Letters> = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
                                                       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"};
 template<>
-std::array<std::string_view, 5> names_of<NonContigFlagsWithNoneCStyle> = {"None", "Flag0", "Flag1", "Flag2", "Flag6"};
+std::array<enchantum::string_view, 5> names_of<NonContigFlagsWithNoneCStyle> = {"None", "Flag0", "Flag1", "Flag2", "Flag6"};
 template<>
-std::array<std::string_view, 9> names_of<FlagsWithNone> =
+std::array<enchantum::string_view, 9> names_of<FlagsWithNone> =
   {"None", "Flag0", "Flag1", "Flag2", "Flag3", "Flag4", "Flag5", "Flag6", "Flag7"};
 template<>
-std::array<std::string_view, 5> names_of<Direction2D> = {"None", "Left", "Up", "Right", "Down"};
+std::array<enchantum::string_view, 5> names_of<Direction2D> = {"None", "Left", "Up", "Right", "Down"};
 template<>
-std::array<std::string_view, 7> names_of<Direction3D> = {"None", "Left", "Up", "Right", "Down", "Front", "Back"};
+std::array<enchantum::string_view, 7> names_of<Direction3D> = {"None", "Left", "Up", "Right", "Down", "Front", "Back"};
 template<>
-std::array<std::string_view, 7> names_of<CStyleFromA_To_G> = {"a", "b", "c", "e", "d", "f", "g"};
+std::array<enchantum::string_view, 7> names_of<CStyleFromA_To_G> = {"a", "b", "c", "e", "d", "f", "g"};
 template<>
-std::array<std::string_view, 2> names_of<MinMaxValues> = {"min", "max"};
+std::array<enchantum::string_view, 2> names_of<MinMaxValues> = {"min", "max"};
 template<>
-std::array<std::string_view, 2> names_of<MinMaxValuesCStyle> = {"MinMaxValuesCStyle_min", "MinMaxValuesCStyle_max"};
+std::array<enchantum::string_view, 2> names_of<MinMaxValuesCStyle> = {"MinMaxValuesCStyle_min", "MinMaxValuesCStyle_max"};
 
 template<>
-std::array<std::string_view, 7> names_of<Outer::Inner::Anon> = {"_0", "_1", "_2", "_3", "_4", "_5", "_6"};
+std::array<enchantum::string_view, 7> names_of<Outer::Inner::Anon> = {"_0", "_1", "_2", "_3", "_4", "_5", "_6"};
 template<>
-std::array<std::string_view, 7> names_of<Outer::Inner::CStyleAnon> =
+std::array<enchantum::string_view, 7> names_of<Outer::Inner::CStyleAnon> =
   {"CStyleAnon_0", "CStyleAnon_1", "CStyleAnon_2", "CStyleAnon_3", "CStyleAnon_4", "CStyleAnon_5", "CStyleAnon_6"};
 template<>
-std::array<std::string_view, 5> names_of<UnscopedCStyle> =
+std::array<enchantum::string_view, 5> names_of<UnscopedCStyle> =
   {"Unscoped_CStyle_Val0",
    "Unscoped_CStyle_Value1",
    "Unscoped_CStyle_Value4",
    "Unscoped_CStyle_Value3",
    "Unscoped_CStyle_Value2"};
 template<>
-std::array<std::string_view, 2> names_of<BoolEnum> = {"False", "True"};
+std::array<enchantum::string_view, 2> names_of<BoolEnum> = {"False", "True"};
 template<>
-std::array<std::string_view, 2> names_of<BoolEnumCStyle> = {"BoolEnumCStyle_False", "BoolEnumCStyle_True"};
+std::array<enchantum::string_view, 2> names_of<BoolEnumCStyle> = {"BoolEnumCStyle_False", "BoolEnumCStyle_True"};
 
 
 
 template<>
-auto values_of<Color> = std::array{Color::Aqua, Color::Purple, Color::Green, Color::Red, Color::Blue};
+auto values_of<Color> = TESTS_CPP14_MAKE_ARRAY(Color::Aqua, Color::Purple, Color::Green, Color::Red, Color::Blue);
 template<>
-auto values_of<Flags> = std::array{Flags::Flag0, Flags::Flag1, Flags::Flag2, Flags::Flag3, Flags::Flag4, Flags::Flag5, Flags::Flag6};
+auto values_of<Flags> = TESTS_CPP14_MAKE_ARRAY(Flags::Flag0, Flags::Flag1, Flags::Flag2, Flags::Flag3, Flags::Flag4, Flags::Flag5, Flags::Flag6);
 template<>
-auto values_of<UnscopedColor> = std::array{UnscopedColor::Aqua,
+auto values_of<UnscopedColor> = TESTS_CPP14_MAKE_ARRAY(UnscopedColor::Aqua,
                                            UnscopedColor::Purple,
                                            UnscopedColor::Green,
                                            UnscopedColor::Red,
-                                           UnscopedColor::Blue};
+                                           UnscopedColor::Blue);
 template<>
-auto values_of<BlockType> = std::array{BlockType::Dirt, BlockType::Stone, BlockType::Obsidian};
+auto values_of<BlockType> = TESTS_CPP14_MAKE_ARRAY(BlockType::Dirt, BlockType::Stone, BlockType::Obsidian);
 template<>
-auto values_of<StrongFlagsNoOverloadedOperators> = std::array{StrongFlagsNoOverloadedOperators::Flag0,
+auto values_of<StrongFlagsNoOverloadedOperators> = TESTS_CPP14_MAKE_ARRAY(StrongFlagsNoOverloadedOperators::Flag0,
                                                               StrongFlagsNoOverloadedOperators::Flag1,
                                                               StrongFlagsNoOverloadedOperators::Flag2,
                                                               StrongFlagsNoOverloadedOperators::Flag3,
                                                               StrongFlagsNoOverloadedOperators::Flag4,
                                                               StrongFlagsNoOverloadedOperators::Flag5,
-                                                              StrongFlagsNoOverloadedOperators::Flag6};
+                                                              StrongFlagsNoOverloadedOperators::Flag6);
 template<>
-auto values_of<ImGuiFreeTypeBuilderFlags> = std::array{ImGuiFreeTypeBuilderFlags_NoHinting,
+auto values_of<ImGuiFreeTypeBuilderFlags> = TESTS_CPP14_MAKE_ARRAY(ImGuiFreeTypeBuilderFlags_NoHinting,
                                                        ImGuiFreeTypeBuilderFlags_NoAutoHint,
                                                        ImGuiFreeTypeBuilderFlags_ForceAutoHint,
                                                        ImGuiFreeTypeBuilderFlags_LightHinting,
@@ -224,10 +236,10 @@ auto values_of<ImGuiFreeTypeBuilderFlags> = std::array{ImGuiFreeTypeBuilderFlags
                                                        ImGuiFreeTypeBuilderFlags_Oblique,
                                                        ImGuiFreeTypeBuilderFlags_Monochrome,
                                                        ImGuiFreeTypeBuilderFlags_LoadColor,
-                                                       ImGuiFreeTypeBuilderFlags_Bitmap};
+                                                       ImGuiFreeTypeBuilderFlags_Bitmap);
 
 template<>
-auto values_of<ContigNonZero> = std::array{ContigNonZero::_0,
+auto values_of<ContigNonZero> = TESTS_CPP14_MAKE_ARRAY(ContigNonZero::_0,
                                            ContigNonZero::_1,
                                            ContigNonZero::_2,
                                            ContigNonZero::_3,
@@ -236,9 +248,9 @@ auto values_of<ContigNonZero> = std::array{ContigNonZero::_0,
                                            ContigNonZero::_6,
                                            ContigNonZero::_7,
                                            ContigNonZero::_8,
-                                           ContigNonZero::_9};
+                                           ContigNonZero::_9);
 template<>
-auto values_of<ContigNonZeroCStyle> = std::array{ContigNonZeroCStyle_0,
+auto values_of<ContigNonZeroCStyle> = TESTS_CPP14_MAKE_ARRAY(ContigNonZeroCStyle_0,
                                                  ContigNonZeroCStyle_1,
                                                  ContigNonZeroCStyle_2,
                                                  ContigNonZeroCStyle_3,
@@ -247,9 +259,9 @@ auto values_of<ContigNonZeroCStyle> = std::array{ContigNonZeroCStyle_0,
                                                  ContigNonZeroCStyle_6,
                                                  ContigNonZeroCStyle_7,
                                                  ContigNonZeroCStyle_8,
-                                                 ContigNonZeroCStyle_9};
+                                                 ContigNonZeroCStyle_9);
 template<>
-auto values_of<ContigNonZeroStartWith5CStyle> = std::array{ContigNonZeroStartWith5CStyle_0,
+auto values_of<ContigNonZeroStartWith5CStyle> = TESTS_CPP14_MAKE_ARRAY(ContigNonZeroStartWith5CStyle_0,
                                                            ContigNonZeroStartWith5CStyle_1,
                                                            ContigNonZeroStartWith5CStyle_2,
                                                            ContigNonZeroStartWith5CStyle_3,
@@ -258,9 +270,9 @@ auto values_of<ContigNonZeroStartWith5CStyle> = std::array{ContigNonZeroStartWit
                                                            ContigNonZeroStartWith5CStyle_6,
                                                            ContigNonZeroStartWith5CStyle_7,
                                                            ContigNonZeroStartWith5CStyle_8,
-                                                           ContigNonZeroStartWith5CStyle_9};
+                                                           ContigNonZeroStartWith5CStyle_9);
 template<>
-auto values_of<UnderlyingTypeWChar_t> = std::array{UnderlyingTypeWChar_t::_0,
+auto values_of<UnderlyingTypeWChar_t> = TESTS_CPP14_MAKE_ARRAY(UnderlyingTypeWChar_t::_0,
                                                    UnderlyingTypeWChar_t::_1,
                                                    UnderlyingTypeWChar_t::_2,
                                                    UnderlyingTypeWChar_t::_3,
@@ -269,10 +281,10 @@ auto values_of<UnderlyingTypeWChar_t> = std::array{UnderlyingTypeWChar_t::_0,
                                                    UnderlyingTypeWChar_t::_6,
                                                    UnderlyingTypeWChar_t::_7,
                                                    UnderlyingTypeWChar_t::_8,
-                                                   UnderlyingTypeWChar_t::_9};
+                                                   UnderlyingTypeWChar_t::_9);
 #ifdef __cpp_char8_t
 template<>
-auto values_of<UnderlyingTypeChar8_t> = std::array{UnderlyingTypeChar8_t::_0,
+auto values_of<UnderlyingTypeChar8_t> = TESTS_CPP14_MAKE_ARRAY(UnderlyingTypeChar8_t::_0,
                                                    UnderlyingTypeChar8_t::_1,
                                                    UnderlyingTypeChar8_t::_2,
                                                    UnderlyingTypeChar8_t::_3,
@@ -281,11 +293,11 @@ auto values_of<UnderlyingTypeChar8_t> = std::array{UnderlyingTypeChar8_t::_0,
                                                    UnderlyingTypeChar8_t::_6,
                                                    UnderlyingTypeChar8_t::_7,
                                                    UnderlyingTypeChar8_t::_8,
-                                                   UnderlyingTypeChar8_t::_9};
+                                                   UnderlyingTypeChar8_t::_9);
 
 #endif
 template<>
-auto values_of<UnderlyingTypeChar16_t> = std::array{UnderlyingTypeChar16_t::_0,
+auto values_of<UnderlyingTypeChar16_t> = TESTS_CPP14_MAKE_ARRAY(UnderlyingTypeChar16_t::_0,
                                                     UnderlyingTypeChar16_t::_1,
                                                     UnderlyingTypeChar16_t::_2,
                                                     UnderlyingTypeChar16_t::_3,
@@ -294,9 +306,9 @@ auto values_of<UnderlyingTypeChar16_t> = std::array{UnderlyingTypeChar16_t::_0,
                                                     UnderlyingTypeChar16_t::_6,
                                                     UnderlyingTypeChar16_t::_7,
                                                     UnderlyingTypeChar16_t::_8,
-                                                    UnderlyingTypeChar16_t::_9};
+                                                    UnderlyingTypeChar16_t::_9);
 template<>
-auto values_of<UnderlyingTypeChar32_t> = std::array{UnderlyingTypeChar32_t::_0,
+auto values_of<UnderlyingTypeChar32_t> = TESTS_CPP14_MAKE_ARRAY(UnderlyingTypeChar32_t::_0,
                                                     UnderlyingTypeChar32_t::_1,
                                                     UnderlyingTypeChar32_t::_2,
                                                     UnderlyingTypeChar32_t::_3,
@@ -305,21 +317,21 @@ auto values_of<UnderlyingTypeChar32_t> = std::array{UnderlyingTypeChar32_t::_0,
                                                     UnderlyingTypeChar32_t::_6,
                                                     UnderlyingTypeChar32_t::_7,
                                                     UnderlyingTypeChar32_t::_8,
-                                                    UnderlyingTypeChar32_t::_9};
+                                                    UnderlyingTypeChar32_t::_9);
 
 template<>
-auto values_of<Letters> = std::array{Letters::a, Letters::b, Letters::c, Letters::d, Letters::e, Letters::f, Letters::g,
+auto values_of<Letters> = TESTS_CPP14_MAKE_ARRAY(Letters::a, Letters::b, Letters::c, Letters::d, Letters::e, Letters::f, Letters::g,
                                      Letters::h, Letters::i, Letters::j, Letters::k, Letters::l, Letters::m, Letters::n,
                                      Letters::o, Letters::p, Letters::q, Letters::r, Letters::s, Letters::t, Letters::u,
-                                     Letters::v, Letters::w, Letters::x, Letters::y, Letters::z};
+                                     Letters::v, Letters::w, Letters::x, Letters::y, Letters::z);
 template<>
-auto values_of<NonContigFlagsWithNoneCStyle> = std::array{NonContigFlagsWithNoneCStyle::None,
+auto values_of<NonContigFlagsWithNoneCStyle> = TESTS_CPP14_MAKE_ARRAY(NonContigFlagsWithNoneCStyle::None,
                                                           NonContigFlagsWithNoneCStyle::Flag0,
                                                           NonContigFlagsWithNoneCStyle::Flag1,
                                                           NonContigFlagsWithNoneCStyle::Flag2,
-                                                          NonContigFlagsWithNoneCStyle::Flag6};
+                                                          NonContigFlagsWithNoneCStyle::Flag6);
 template<>
-auto values_of<FlagsWithNone> = std::array{FlagsWithNone::None,
+auto values_of<FlagsWithNone> = TESTS_CPP14_MAKE_ARRAY(FlagsWithNone::None,
                                            FlagsWithNone::Flag0,
                                            FlagsWithNone::Flag1,
                                            FlagsWithNone::Flag2,
@@ -327,56 +339,56 @@ auto values_of<FlagsWithNone> = std::array{FlagsWithNone::None,
                                            FlagsWithNone::Flag4,
                                            FlagsWithNone::Flag5,
                                            FlagsWithNone::Flag6,
-                                           FlagsWithNone::Flag7};
+                                           FlagsWithNone::Flag7);
 template<>
-auto values_of<Direction2D> = std::array{Direction2D::None, Direction2D::Left, Direction2D::Up, Direction2D::Right, Direction2D::Down};
+auto values_of<Direction2D> = TESTS_CPP14_MAKE_ARRAY(Direction2D::None, Direction2D::Left, Direction2D::Up, Direction2D::Right, Direction2D::Down);
 template<>
-auto values_of<Direction3D> = std::array{Direction3D::None,
+auto values_of<Direction3D> = TESTS_CPP14_MAKE_ARRAY(Direction3D::None,
                                          Direction3D::Left,
                                          Direction3D::Up,
                                          Direction3D::Right,
                                          Direction3D::Down,
                                          Direction3D::Front,
-                                         Direction3D::Back};
+                                         Direction3D::Back);
 template<>
-auto values_of<CStyleFromA_To_G> = std::array{CStyleFromA_To_G::a,
+auto values_of<CStyleFromA_To_G> = TESTS_CPP14_MAKE_ARRAY(CStyleFromA_To_G::a,
                                               CStyleFromA_To_G::b,
                                               CStyleFromA_To_G::c,
                                               CStyleFromA_To_G::e,
                                               CStyleFromA_To_G::d,
                                               CStyleFromA_To_G::f,
-                                              CStyleFromA_To_G::g};
+                                              CStyleFromA_To_G::g);
 template<>
-auto values_of<MinMaxValues> = std::array{MinMaxValues::min, MinMaxValues::max};
+auto values_of<MinMaxValues> = TESTS_CPP14_MAKE_ARRAY(MinMaxValues::min, MinMaxValues::max);
 template<>
-auto values_of<MinMaxValuesCStyle> = std::array{MinMaxValuesCStyle_min, MinMaxValuesCStyle_max};
+auto values_of<MinMaxValuesCStyle> = TESTS_CPP14_MAKE_ARRAY(MinMaxValuesCStyle_min, MinMaxValuesCStyle_max);
 
 template<>
-auto values_of<Outer::Inner::Anon> = std::array{Outer::Inner::Anon::_0,
+auto values_of<Outer::Inner::Anon> = TESTS_CPP14_MAKE_ARRAY(Outer::Inner::Anon::_0,
                                                 Outer::Inner::Anon::_1,
                                                 Outer::Inner::Anon::_2,
                                                 Outer::Inner::Anon::_3,
                                                 Outer::Inner::Anon::_4,
                                                 Outer::Inner::Anon::_5,
-                                                Outer::Inner::Anon::_6};
+                                                Outer::Inner::Anon::_6);
 template<>
-auto values_of<Outer::Inner::CStyleAnon> = std::array{Outer::Inner::CStyleAnon_0,
+auto values_of<Outer::Inner::CStyleAnon> = TESTS_CPP14_MAKE_ARRAY(Outer::Inner::CStyleAnon_0,
                                                       Outer::Inner::CStyleAnon_1,
                                                       Outer::Inner::CStyleAnon_2,
                                                       Outer::Inner::CStyleAnon_3,
                                                       Outer::Inner::CStyleAnon_4,
                                                       Outer::Inner::CStyleAnon_5,
-                                                      Outer::Inner::CStyleAnon_6};
+                                                      Outer::Inner::CStyleAnon_6);
 template<>
-auto values_of<UnscopedCStyle> = std::array{Unscoped_CStyle_Val0,
+auto values_of<UnscopedCStyle> = TESTS_CPP14_MAKE_ARRAY(Unscoped_CStyle_Val0,
                                             Unscoped_CStyle_Value1,
                                             Unscoped_CStyle_Value4,
                                             Unscoped_CStyle_Value3,
-                                            Unscoped_CStyle_Value2};
+                                            Unscoped_CStyle_Value2);
 template<>
-auto values_of<BoolEnum> = std::array{BoolEnum::False, BoolEnum::True};
+auto values_of<BoolEnum> = TESTS_CPP14_MAKE_ARRAY(BoolEnum::False, BoolEnum::True);
 template<>
-auto values_of<BoolEnumCStyle> = std::array{BoolEnumCStyle_False, BoolEnumCStyle_True};
+auto values_of<BoolEnumCStyle> = TESTS_CPP14_MAKE_ARRAY(BoolEnumCStyle_False, BoolEnumCStyle_True);
 
 
 TEMPLATE_LIST_TEST_CASE("array size checks", "[constants]", AllEnumsTestTypes)
@@ -454,7 +466,7 @@ TEMPLATE_LIST_TEST_CASE("array size checks", "[constants]", AllEnumsTestTypes)
 
       CHECK(typeid(x[0]) == typeid(x[1]));
 
-      STATIC_CHECK(std::is_same_v<std::decay_t<decltype(x[0])>, std::decay_t<decltype(y[0])>>);
+      STATIC_CHECK((std::is_same<std::decay_t<decltype(x[0])>, std::decay_t<decltype(y[0])>>::value));
 
 
       REQUIRE(x.size() == y.size());
@@ -475,7 +487,7 @@ TEMPLATE_LIST_TEST_CASE("array size checks", "[constants]", AllEnumsTestTypes)
 
       REQUIRE(x.size() == y.size());
 
-      STATIC_CHECK(std::is_same_v<std::decay_t<decltype(x[0])>, std::decay_t<decltype(y[0])>>);
+      STATIC_CHECK((std::is_same<std::decay_t<decltype(x[0])>, std::decay_t<decltype(y[0])>>::value));
 
       for (std::size_t i = 0; i < x.size(); ++i)
         CHECK(x[i] == y[i]);

--- a/tests/functors.cpp
+++ b/tests/functors.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_tostring.hpp>
 #include <enchantum/enchantum.hpp>
+#include <enchantum/details/optional.hpp>
 
 template<typename It, typename Out, typename Func>
 void transform_unwrap(It begin, const It end, Out out, const Func f)
@@ -15,7 +16,7 @@ void transform_unwrap(It begin, const It end, Out out, const Func f)
 TEMPLATE_LIST_TEST_CASE("cast is a functor", "[functors]", AllEnumsTestTypes)
 {
   constexpr auto&                                     strings = enchantum::names<TestType>;
-  std::array<std::optional<TestType>, strings.size()> values;
+  std::array<enchantum::optional<TestType>, strings.size()> values;
 
   std::transform(strings.begin(), strings.end(), values.begin(), enchantum::cast<TestType>);
 
@@ -25,8 +26,8 @@ TEMPLATE_LIST_TEST_CASE("cast is a functor", "[functors]", AllEnumsTestTypes)
 TEMPLATE_LIST_TEST_CASE("enum_to_index and index_to_enum are functors", "[functors]", AllEnumsTestTypes)
 {
   constexpr auto&                                       values = enchantum::values<TestType>;
-  std::array<std::optional<std::size_t>, values.size()> indices;
-  std::array<std::optional<TestType>, values.size()>    values_transformed;
+  std::array<enchantum::optional<std::size_t>, values.size()> indices;
+  std::array<enchantum::optional<TestType>, values.size()>    values_transformed;
 
   std::transform(values.begin(), values.end(), indices.begin(), enchantum::enum_to_index);
   transform_unwrap(indices.begin(), indices.end(), values_transformed.begin(), enchantum::index_to_enum<TestType>);

--- a/tests/next_value.cpp
+++ b/tests/next_value.cpp
@@ -11,7 +11,7 @@ TEMPLATE_LIST_TEST_CASE("next_value identities", "[next_value]", AllEnumsTestTyp
     CHECK(v == enchantum::next_value_circular(v, count));
     CHECK(v == enchantum::prev_value_circular(v, count));
 
-    std::optional<TestType> value = v;
+    enchantum::optional<TestType> value = v;
     for (std::size_t i = 0; i < count - *enchantum::enum_to_index(v); ++i)
       value = enchantum::next_value(*value, 1);
     CHECK_FALSE(value.has_value());

--- a/tests/null_terminated.cpp
+++ b/tests/null_terminated.cpp
@@ -15,7 +15,7 @@ TEMPLATE_LIST_TEST_CASE("entries<E> strings null-terminated character arrays", "
 
   SECTION("Not Null Terminated")
   {
-    constexpr auto names  = enchantum::names<TestType, std::string_view, false>;
+    constexpr auto names  = enchantum::names<TestType, enchantum::string_view, false>;
     const auto* names_ptr = names[0].data(); // implementation detail but all strings are allocated next to each other
     for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(names.size()) - 1; ++i) {
       const auto& name = names[static_cast<std::size_t>(i)];

--- a/tests/test_utility.hpp
+++ b/tests/test_utility.hpp
@@ -74,6 +74,8 @@ ENCHANTUM_DEFINE_BITWISE_FOR(Flags)
 } // namespace Namespace2
 } // namespace LongNamespaced
 
+namespace {
+
 enum class StrongFlagsNoOverloadedOperators : std::uint8_t {
   Flag0 = 1 << 0,
   Flag1 = 1 << 1,
@@ -83,12 +85,6 @@ enum class StrongFlagsNoOverloadedOperators : std::uint8_t {
   Flag5 = 1 << 5,
   Flag6 = 1 << 6,
 };
-
-template<>
-ENCHANTUM_DETAILS_INLINE_VAR constexpr bool enchantum::is_bitflag<StrongFlagsNoOverloadedOperators> = true;
-
-// taken from ImGui.
-// https://github.com/ocornut/imgui/blob/46235e91f602b663f9b0f1f1a300177b61b193f5/misc/freetype/imgui_freetype.h#L26
 
 enum ImGuiFreeTypeBuilderFlags {
   ImGuiFreeTypeBuilderFlags_NoHinting     = 1 << 0,
@@ -102,6 +98,14 @@ enum ImGuiFreeTypeBuilderFlags {
   ImGuiFreeTypeBuilderFlags_LoadColor     = 1 << 8,
   ImGuiFreeTypeBuilderFlags_Bitmap        = 1 << 9
 };
+
+} // namespace
+
+template<>
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool enchantum::is_bitflag<StrongFlagsNoOverloadedOperators> = true;
+
+// taken from ImGui.
+// https://github.com/ocornut/imgui/blob/46235e91f602b663f9b0f1f1a300177b61b193f5/misc/freetype/imgui_freetype.h#L26
 
 template<>
 struct enchantum::enum_traits<ImGuiFreeTypeBuilderFlags> {

--- a/tests/test_utility.hpp
+++ b/tests/test_utility.hpp
@@ -12,7 +12,8 @@ template<typename... Commas>
 struct TypeWithCommas;
 
 // Tests whether string parsing will break if commas occur in typename
-namespace LongNamespaced::Namespace2 {
+namespace LongNamespaced {
+namespace Namespace2 {
   inline namespace InlineNamespace {
 template<typename... IAmHereForCommasInTypeName>
 struct Really_Unreadable_Class_Name {
@@ -70,7 +71,8 @@ using UnscopedColor = UglyType::UnscopedColor;
 
 ENCHANTUM_DEFINE_BITWISE_FOR(Flags)
   }
-} // namespace LongNamespaced::Namespace2::inline InlineNamespace
+} // namespace Namespace2
+} // namespace LongNamespaced
 
 enum class StrongFlagsNoOverloadedOperators : std::uint8_t {
   Flag0 = 1 << 0,
@@ -83,7 +85,7 @@ enum class StrongFlagsNoOverloadedOperators : std::uint8_t {
 };
 
 template<>
-inline constexpr bool enchantum::is_bitflag<StrongFlagsNoOverloadedOperators> = true;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool enchantum::is_bitflag<StrongFlagsNoOverloadedOperators> = true;
 
 // taken from ImGui.
 // https://github.com/ocornut/imgui/blob/46235e91f602b663f9b0f1f1a300177b61b193f5/misc/freetype/imgui_freetype.h#L26
@@ -108,7 +110,7 @@ struct enchantum::enum_traits<ImGuiFreeTypeBuilderFlags> {
   static constexpr auto        max           = int(ImGuiFreeTypeBuilderFlags_Bitmap);
 };
 template<>
-inline constexpr bool enchantum::is_bitflag<ImGuiFreeTypeBuilderFlags> = true;
+ENCHANTUM_DETAILS_INLINE_VAR constexpr bool enchantum::is_bitflag<ImGuiFreeTypeBuilderFlags> = true;
 
 namespace {
 
@@ -560,8 +562,9 @@ using AllEnumsTestTypes = concat<
     Outer::Inner::CStyleAnon>>;
 
 
+namespace Catch {
 template<typename E>
-struct Catch::StringMaker<E,std::enable_if_t<std::is_enum_v<E>>> {
+struct StringMaker<E, std::enable_if_t<std::is_enum<E>::value>> {
   static std::string convert(E e)
   {
     return '"' + std::to_string(static_cast<std::underlying_type_t<E>>(e)) + '"';
@@ -573,3 +576,4 @@ struct Catch::StringMaker<E,std::enable_if_t<std::is_enum_v<E>>> {
     //    std::to_string(static_cast<std::underlying_type_t<E>>(e)) + ")";
   }
 };
+} // namespace Catch


### PR DESCRIPTION
## Motivation

Replaces #30 after renaming the fork branch to `feature/portable-cpp14-support`.

Closes #19.

This PR adds portable C++14 support while preserving the current zero-configuration behavior for C++17 and newer users.

The main compatibility issue is that enchantum uses `optional` and `string_view`-style APIs, but C++14 has no standard `std::optional` or `std::string_view`. Instead of adding a bundled polyfill or injecting aliases into `namespace std`, this PR makes C++14 support explicit: C++14 consumers provide the aliases they want to use, while C++17/C++20 continue using the standard library defaults.

This also adds CI coverage so C++14 support does not silently regress, and includes compile-time regression checks for the existing C++17/C++20 builds.

## Compatibility Model

For C++17 and newer:

- No user action is required.
- Existing defaults continue to use standard library facilities.
- The public behavior is intended to remain unchanged.

For C++14:

- Users must define `ENCHANTUM_ALIAS_OPTIONAL`.
- Users must define `ENCHANTUM_ALIAS_STRING_VIEW`.
- Tests provide these aliases through the C++14 test config.
- The library does not add aliases into `namespace std`.

This keeps C++14 support opt-in and avoids choosing a project-specific polyfill for downstream users.

## Main Changes

- Add compatibility helpers for detecting the active C++ standard and selecting alias-based optional/string-view support.
- Port the headers that used C++17-only constructs so they can compile under C++14 when aliases are supplied.
- Add C++14 smoke tests for modular headers and the generated single header.
- Add a C++14 full-suite test target with CTest-discovered tests prefixed as `cpp14_full::`.
- Keep the primary `tests` target on C++17+ behavior instead of replacing it with the C++14 configuration.
- Update CI to build and run the C++14 targets.
- Add a dedicated C++14 regression workflow that also measures C++17/C++20 build times against `main`.
- Restore C++17/C++20 compile-time fast paths in traits, generators, fold-expression paths, and parser signature extraction.
- Mirror the modular-header changes into `single_include/enchantum_single_header.hpp`.

## Notes On Parser Changes

The parser signature extraction paths were split so C++17+ can continue using the faster `template<auto...>` / `template<auto>` style paths where available, while C++14 keeps the typed NTTP/scanning-compatible paths.

The GCC parser path also keeps explicit null checks around `std::char_traits<char>::find` results before pointer arithmetic.

## CI And Test Coverage

Local MSVC verification from this branch:

- C++14 CTest: `1113/1113` passed
- C++17 CTest: `1113/1113` passed
- C++20 CTest: `1176/1176` passed

Hosted fork workflow:

- Workflow: `C++14 Regression Checks`
- Run: https://github.com/Godzilla675/enchantum/actions/runs/25967699544
- Result: passed
- Head SHA: `ae4d3efc57c648df5039a2536cf7351cc4042e44`

The hosted workflow covered GCC, Clang, MSVC, and macOS jobs in addition to the timing jobs.

## Build-Time Regression Timing

Latest hosted timing results from the fork workflow:

| Compiler | Standard | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: | ---: |
| GCC 14 | C++17 | `140s` | `140s` | `0s / 0.0%` |
| GCC 14 | C++20 | `180s` | `188s` | `+8s / +4.4%` |
| MSVC 2022 | C++17 | `197s` | `174s` | `-23s / -11.7%` |
| MSVC 2022 | C++20 | `300s` | `302s` | `+2s / +0.7%` |

The original C++17 regression has been recovered in these measurements. C++20 is still slightly slower in the hosted timing run, but much closer after restoring the fast paths.

## Known Limitations

- C++14 support intentionally requires caller-provided optional/string-view aliases; this PR does not ship a polyfill.
- There is no negative CI test that intentionally omits the required C++14 aliases.
- Single-header consistency is covered by compiling/running the single-header C++14 smoke target, not by an automated generator diff.
- The regression timing workflow is currently scoped to this branch/manual workflow rather than enforced on every upstream PR.