### PR TITLE
Fix __builtin_memcmp warning as error in gcc 11.4.0

### DIFF
--- a/enchantum/include/enchantum/scoped.hpp
+++ b/enchantum/include/enchantum/scoped.hpp
@@ -21,7 +21,11 @@ namespace scoped {
 
     constexpr string_view remove_scope_or_empty(string_view string, const string_view type_name) noexcept
     {
-      const auto starts_with = [](auto a, auto b) { return a.substr(0, b.size()) == b; };
+      const auto starts_with = [](auto a, auto b) {
+        // The a.size() >= b.size() check is not necessary here, but it is needed
+        // to silence a warning in gcc 11.
+        return a.size() >= b.size() && a.substr(0, b.size()) == b;
+      };
       if (!starts_with(string, type_name))
         return string_view();
       string.remove_prefix(type_name.size());


### PR DESCRIPTION
There was a warning being emitted with string_view operator== on gcc 11.4.0 due to __builtin_memcmp seeing and out of bounds memory comparison. This is fixed via an additional check in the starts_with lambda in the remove_scope_or_empty function to see if the source string is shorter than the string we are checking to see if it starts with. This would always be false since the source is shorter than the checking-against-string.